### PR TITLE
Add soft and hard line break parsing for Markdown

### DIFF
--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -109,6 +109,15 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(result.root.children.first?.value, "*not italic*")
     }
 
+    func testMarkdownHardBreak() {
+        let parser = SwiftParser()
+        let source = "Hello  \nWorld"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        XCTAssertEqual(result.root.children.count, 1)
+        XCTAssertEqual(result.root.children.first?.value, "Hello\nWorld")
+    }
+
     func testPrattExpression() {
         let parser = SwiftParser()
         let source = "x = 1 + 2 * 3"


### PR DESCRIPTION
## Summary
- expand Markdown tokens with `softBreak` and `hardBreak`
- update tokenizer to detect two-space hard breaks
- treat soft/hard breaks inside paragraphs
- adjust builders to recognise new line break tokens
- test hard break handling

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6875400291a08322b22d8061a0af9f7e