### PR TITLE
Track list nesting level

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -47,15 +47,31 @@ public final class MarkdownOrderedListItemNode: CodeNode {
     }
 }
 
-public final class MarkdownUnorderedListNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.unorderedList, value: value, range: range)
+public class MarkdownListNode: CodeNode {
+    public let level: Int
+    public init(type: any CodeElement, value: String = "", level: Int, range: Range<String.Index>? = nil) {
+        self.level = level
+        super.init(type: type, value: value, range: range)
+    }
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(value)
+        hasher.combine(level)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
     }
 }
 
-public final class MarkdownOrderedListNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.orderedList, value: value, range: range)
+public final class MarkdownUnorderedListNode: MarkdownListNode {
+    public init(value: String = "", level: Int, range: Range<String.Index>? = nil) {
+        super.init(type: MarkdownLanguage.Element.unorderedList, value: value, level: level, range: range)
+    }
+}
+
+public final class MarkdownOrderedListNode: MarkdownListNode {
+    public init(value: String = "", level: Int, range: Range<String.Index>? = nil) {
+        super.init(type: MarkdownLanguage.Element.orderedList, value: value, level: level, range: range)
     }
 }
 

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -58,6 +58,7 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(list?.type as? MarkdownLanguage.Element, .unorderedList)
         XCTAssertEqual(list?.children.count, 2)
         XCTAssertEqual(list?.children.first?.type as? MarkdownLanguage.Element, .listItem)
+        XCTAssertEqual((list as? MarkdownUnorderedListNode)?.level, 1)
     }
 
     func testMarkdownOrderedList() {
@@ -69,6 +70,7 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(list?.type as? MarkdownLanguage.Element, .orderedList)
         XCTAssertEqual(list?.children.count, 2)
         XCTAssertEqual(list?.children.first?.type as? MarkdownLanguage.Element, .orderedListItem)
+        XCTAssertEqual((list as? MarkdownOrderedListNode)?.level, 1)
     }
 
     func testMarkdownNestedList() {
@@ -81,6 +83,8 @@ final class SwiftParserTests: XCTestCase {
         XCTAssertEqual(list?.children.count, 2)
         let sub = list?.children.first?.children.first
         XCTAssertEqual(sub?.type as? MarkdownLanguage.Element, .unorderedList)
+        XCTAssertEqual((list as? MarkdownUnorderedListNode)?.level, 1)
+        XCTAssertEqual((sub as? MarkdownUnorderedListNode)?.level, 2)
     }
 
     func testMarkdownLooseList() {


### PR DESCRIPTION
## Summary
- add `MarkdownListNode` base class with `level`
- update `UnorderedListBuilder` and `OrderedListBuilder` to record the list level when building
- extend tests to verify list level property

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6875be86fa0c8322aa79b02acfee69c3