### PR TITLE
Add structured markdown reference & footnote nodes

### DIFF
--- a/Sources/SwiftParser/Languages/MarkdownLanguage.swift
+++ b/Sources/SwiftParser/Languages/MarkdownLanguage.swift
@@ -27,6 +27,8 @@ public struct MarkdownLanguage: CodeLanguage {
         case tableCell
         case autoLink
         case linkReferenceDefinition
+        case footnoteDefinition
+        case footnoteReference
     }
 
     public enum Token: CodeToken {
@@ -1147,20 +1149,42 @@ public struct MarkdownLanguage: CodeLanguage {
     public class FootnoteBuilder: CodeElementBuilder {
         public init() {}
         public func accept(context: CodeContext, token: any CodeToken) -> Bool {
-            guard context.index + 3 < context.tokens.count else { return false }
-            guard let lb = token as? Token,
-                  let txt = context.tokens[context.index + 1] as? Token,
-                  let rb = context.tokens[context.index + 2] as? Token else { return false }
-            if case .lbracket = lb,
-               case .text(let s, _) = txt, s.starts(with: "^") ,
-               case .rbracket = rb {
-                return true
+            guard let lb = token as? Token, case .lbracket = lb else { return false }
+            guard context.index + 2 < context.tokens.count else { return false }
+            guard let first = context.tokens[context.index + 1] as? Token else { return false }
+            if case .text(let s, _) = first, s.starts(with: "^") {
+                var idx = context.index + 2
+                while idx < context.tokens.count {
+                    if let t = context.tokens[idx] as? Token {
+                        if case .rbracket = t { return true }
+                        if case .text = t {
+                            idx += 1; continue
+                        }
+                        if case .number = t {
+                            idx += 1; continue
+                        }
+                    }
+                    break
+                }
             }
             return false
         }
         public func build(context: inout CodeContext) {
-            context.index += 3 // skip [^x]
-            if context.index < context.tokens.count, let colon = context.tokens[context.index] as? Token, case .text(let s, _) = colon, s.trimmingCharacters(in: .whitespaces).hasPrefix(":") {
+            context.index += 1 // skip [
+            var id = ""
+            while context.index < context.tokens.count {
+                guard let tok = context.tokens[context.index] as? Token else { context.index += 1; continue }
+                if case .rbracket = tok { break }
+                id += tok.text
+                context.index += 1
+            }
+            if id.hasPrefix("^") { id.removeFirst() }
+            if context.index < context.tokens.count { context.index += 1 } // skip ]
+
+            if context.index < context.tokens.count,
+               let colon = context.tokens[context.index] as? Token,
+               case .text(let s, _) = colon,
+               s.trimmingCharacters(in: .whitespaces).hasPrefix(":") {
                 var text = s
                 context.index += 1
                 while context.index < context.tokens.count {
@@ -1169,7 +1193,11 @@ public struct MarkdownLanguage: CodeLanguage {
                         else { text += tok.text; context.index += 1 }
                     } else { context.index += 1 }
                 }
-                context.currentNode.addChild(MarkdownTextNode(value: text.trimmingCharacters(in: .whitespaces)))
+                if text.hasPrefix(":") { text.removeFirst() }
+                let trimmed = text.trimmingCharacters(in: .whitespaces)
+                context.currentNode.addChild(MarkdownFootnoteDefinitionNode(identifier: id, text: trimmed))
+            } else {
+                context.currentNode.addChild(MarkdownFootnoteReferenceNode(identifier: id))
             }
         }
     }
@@ -1213,8 +1241,9 @@ public struct MarkdownLanguage: CodeLanguage {
             var url = text.trimmingCharacters(in: .whitespaces)
             if url.hasPrefix(":") { url.removeFirst() }
             url = url.trimmingCharacters(in: .whitespaces)
-            context.linkReferences[id.trimmingCharacters(in: .whitespaces).lowercased()] = url
-            context.currentNode.addChild(MarkdownLinkReferenceDefinitionNode(value: id + "|" + url))
+            let trimmedID = id.trimmingCharacters(in: .whitespaces)
+            context.linkReferences[trimmedID.lowercased()] = url
+            context.currentNode.addChild(MarkdownLinkReferenceDefinitionNode(identifier: trimmedID, url: url))
         }
     }
 

--- a/Sources/SwiftParser/Languages/MarkdownNodes.swift
+++ b/Sources/SwiftParser/Languages/MarkdownNodes.swift
@@ -219,7 +219,58 @@ public final class MarkdownAutoLinkNode: CodeNode {
 }
 
 public final class MarkdownLinkReferenceDefinitionNode: CodeNode {
-    public init(value: String = "", range: Range<String.Index>? = nil) {
-        super.init(type: MarkdownLanguage.Element.linkReferenceDefinition, value: value, range: range)
+    public let identifier: String
+    public let url: String
+
+    public init(identifier: String, url: String, range: Range<String.Index>? = nil) {
+        self.identifier = identifier
+        self.url = url
+        super.init(type: MarkdownLanguage.Element.linkReferenceDefinition, value: "", range: range)
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(identifier)
+        hasher.combine(url)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
+    }
+}
+
+public final class MarkdownFootnoteDefinitionNode: CodeNode {
+    public let identifier: String
+    public let text: String
+
+    public init(identifier: String, text: String, range: Range<String.Index>? = nil) {
+        self.identifier = identifier
+        self.text = text
+        super.init(type: MarkdownLanguage.Element.footnoteDefinition, value: "", range: range)
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(identifier)
+        hasher.combine(text)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
+    }
+}
+
+public final class MarkdownFootnoteReferenceNode: CodeNode {
+    public let identifier: String
+
+    public init(identifier: String, range: Range<String.Index>? = nil) {
+        self.identifier = identifier
+        super.init(type: MarkdownLanguage.Element.footnoteReference, value: "", range: range)
+    }
+
+    public override var id: Int {
+        var hasher = Hasher()
+        hasher.combine(String(describing: type))
+        hasher.combine(identifier)
+        for child in children { hasher.combine(child.id) }
+        return hasher.finalize()
     }
 }

--- a/Tests/SwiftParserTests/SwiftParserTests.swift
+++ b/Tests/SwiftParserTests/SwiftParserTests.swift
@@ -415,7 +415,28 @@ final class SwiftParserTests: XCTestCase {
         let result = parser.parse(source, language: MarkdownLanguage())
         XCTAssertEqual(result.errors.count, 0)
         XCTAssertEqual(result.root.children.first?.type as? MarkdownLanguage.Element, .linkReferenceDefinition)
-        XCTAssertEqual(result.root.children.first?.value, "ref|http://example.com")
+        let def = result.root.children.first as? MarkdownLinkReferenceDefinitionNode
+        XCTAssertEqual(def?.identifier, "ref")
+        XCTAssertEqual(def?.url, "http://example.com")
+    }
+
+    func testMarkdownFootnoteDefinition() {
+        let parser = SwiftParser()
+        let source = "[^1]: footnote text"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let node = result.root.children.first as? MarkdownFootnoteDefinitionNode
+        XCTAssertEqual(node?.identifier, "1")
+        XCTAssertEqual(node?.text, "footnote text")
+    }
+
+    func testMarkdownFootnoteReference() {
+        let parser = SwiftParser()
+        let source = "[^1]"
+        let result = parser.parse(source, language: MarkdownLanguage())
+        XCTAssertEqual(result.errors.count, 0)
+        let node = result.root.children.first as? MarkdownFootnoteReferenceNode
+        XCTAssertEqual(node?.identifier, "1")
     }
 
     func testMarkdownAllFeatures() {


### PR DESCRIPTION
## Summary
- extend `MarkdownLanguage.Element` with `footnoteDefinition` and `footnoteReference`
- implement `MarkdownLinkReferenceDefinitionNode` with identifier and url
- add new `MarkdownFootnoteDefinitionNode` and `MarkdownFootnoteReferenceNode`
- parse footnotes using these new nodes
- update link reference definition building
- test footnote parsing and reference definitions

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6876696e11688322aa99e37d63924e78