### PR TITLE
Add Tex formula parser

### DIFF
--- a/Sources/SwiftParserShowCase/Code/Formula/FormulaLanguage.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/FormulaLanguage.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftParser
+
+public class FormulaLanguage: CodeLanguage {
+    public typealias Node = FormulaNodeElement
+    public typealias Token = FormulaTokenElement
+
+    public var tokens: [any CodeTokenBuilder<FormulaTokenElement>]
+    public let nodes: [any CodeNodeBuilder<FormulaNodeElement, FormulaTokenElement>]
+
+    public init() {
+        self.tokens = [
+            FormulaWhitespaceTokenBuilder(),
+            FormulaCommandTokenBuilder(),
+            FormulaNumberTokenBuilder(),
+            FormulaOperatorTokenBuilder(),
+            FormulaDelimiterTokenBuilder(),
+            FormulaIdentifierTokenBuilder()
+        ]
+        self.nodes = [
+            FormulaExpressionBuilder(),
+            FormulaEOFBuilder()
+        ]
+    }
+
+    public func root() -> CodeNode<FormulaNodeElement> {
+        FormulaDocumentNode()
+    }
+
+    public func state() -> (any CodeConstructState<Node, Token>)? { nil }
+    public func state() -> (any CodeTokenState<Token>)? { nil }
+
+    public func eofToken(at range: Range<String.Index>) -> (any CodeToken<FormulaTokenElement>)? {
+        FormulaToken.eof(at: range)
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/FormulaNodeElement.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/FormulaNodeElement.swift
@@ -1,0 +1,11 @@
+import Foundation
+import SwiftParser
+
+public enum FormulaNodeElement: String, CaseIterable, CodeNodeElement {
+    case document
+    case number
+    case identifier
+    case command
+    case binaryOperation
+    case group
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/FormulaNodes.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/FormulaNodes.swift
@@ -1,0 +1,98 @@
+import Foundation
+import SwiftParser
+
+public class FormulaNodeBase: CodeNode<FormulaNodeElement> {
+    public override init(element: FormulaNodeElement) {
+        super.init(element: element)
+    }
+
+    public func append(_ child: FormulaNodeBase) {
+        super.append(child)
+    }
+}
+
+public class FormulaDocumentNode: FormulaNodeBase {
+    public init() {
+        super.init(element: .document)
+    }
+}
+
+public class NumberNode: FormulaNodeBase {
+    public var value: String
+    public init(value: String) {
+        self.value = value
+        super.init(element: .number)
+    }
+
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(value)
+    }
+}
+
+public class IdentifierNode: FormulaNodeBase {
+    public var name: String
+    public init(name: String) {
+        self.name = name
+        super.init(element: .identifier)
+    }
+
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(name)
+    }
+}
+
+public class CommandNode: FormulaNodeBase {
+    public var name: String
+    public var arguments: [FormulaNodeBase]
+
+    public init(name: String, arguments: [FormulaNodeBase]) {
+        self.name = name
+        self.arguments = arguments
+        super.init(element: .command)
+        for arg in arguments { append(arg) }
+    }
+
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(name)
+    }
+}
+
+public enum BinaryOperator: String {
+    case plus = "+"
+    case minus = "-"
+    case times = "*"
+    case divide = "/"
+    case caret = "^"
+    case underscore = "_"
+    case equals = "="
+}
+
+public class BinaryOperationNode: FormulaNodeBase {
+    public var op: BinaryOperator
+    public var left: FormulaNodeBase
+    public var right: FormulaNodeBase
+
+    public init(op: BinaryOperator, left: FormulaNodeBase, right: FormulaNodeBase) {
+        self.op = op
+        self.left = left
+        self.right = right
+        super.init(element: .binaryOperation)
+        append(left)
+        append(right)
+    }
+
+    public override func hash(into hasher: inout Hasher) {
+        super.hash(into: &hasher)
+        hasher.combine(op.rawValue)
+    }
+}
+
+public class GroupNode: FormulaNodeBase {
+    public init(children: [FormulaNodeBase]) {
+        super.init(element: .group)
+        for child in children { append(child) }
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/FormulaToken.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/FormulaToken.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftParser
+
+public class FormulaToken: CodeToken {
+    public typealias Element = FormulaTokenElement
+
+    public let element: FormulaTokenElement
+    public let text: String
+    public let range: Range<String.Index>
+
+    public init(element: FormulaTokenElement, text: String, range: Range<String.Index>) {
+        self.element = element
+        self.text = text
+        self.range = range
+    }
+
+    public static func number(_ text: String, at range: Range<String.Index>) -> FormulaToken {
+        FormulaToken(element: .number, text: text, range: range)
+    }
+
+    public static func identifier(_ text: String, at range: Range<String.Index>) -> FormulaToken {
+        FormulaToken(element: .identifier, text: text, range: range)
+    }
+
+    public static func command(_ name: String, at range: Range<String.Index>) -> FormulaToken {
+        FormulaToken(element: .command, text: name, range: range)
+    }
+
+    public static func symbol(_ element: FormulaTokenElement, at range: Range<String.Index>) -> FormulaToken {
+        FormulaToken(element: element, text: element.rawValue, range: range)
+    }
+
+    public static func eof(at range: Range<String.Index>) -> FormulaToken {
+        FormulaToken(element: .eof, text: "", range: range)
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/FormulaTokenElement.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/FormulaTokenElement.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftParser
+
+public enum FormulaTokenElement: String, CaseIterable, CodeTokenElement {
+    case number
+    case identifier
+    case command
+    case plus
+    case minus
+    case star
+    case slash
+    case caret
+    case underscore
+    case equals
+    case lparen
+    case rparen
+    case lbrace
+    case rbrace
+    case eof
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaEOFBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaEOFBuilder.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftParser
+
+/// Consumes trailing EOF tokens.
+public class FormulaEOFBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? FormulaToken,
+              token.element == .eof else { return false }
+        context.consuming += 1
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaExpressionBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaExpressionBuilder.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftParser
+
+public class FormulaExpressionBuilder: CodeNodeBuilder {
+    public init() {}
+
+    public func build(from context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.tokens.count else { return false }
+        if let token = context.tokens[context.consuming] as? FormulaToken, token.element == .eof {
+            return false
+        }
+        if let expr = FormulaParser.parseExpression(&context) {
+            context.current.append(expr)
+            return true
+        }
+        return false
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaParser.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Nodes/FormulaParser.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SwiftParser
+
+/// Recursive descent parser used by Formula node builders.
+struct FormulaParser {
+    static func parseExpression(_ context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> FormulaNodeBase? {
+        guard let left = parseTerm(&context) else { return nil }
+        var node = left
+        while context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? FormulaToken,
+              token.element == .plus || token.element == .minus || token.element == .equals {
+            context.consuming += 1
+            let op = opFromToken(token.element)
+            guard let right = parseTerm(&context) else { break }
+            node = BinaryOperationNode(op: op, left: node, right: right)
+        }
+        return node
+    }
+
+    private static func parseTerm(_ context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> FormulaNodeBase? {
+        guard let left = parseFactor(&context) else { return nil }
+        var node = left
+        while context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? FormulaToken,
+              token.element == .star || token.element == .slash {
+            context.consuming += 1
+            let op = opFromToken(token.element)
+            guard let right = parseFactor(&context) else { break }
+            node = BinaryOperationNode(op: op, left: node, right: right)
+        }
+        return node
+    }
+
+    private static func parseFactor(_ context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> FormulaNodeBase? {
+        guard var node = parseAtom(&context) else { return nil }
+        while context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? FormulaToken,
+              token.element == .caret || token.element == .underscore {
+            context.consuming += 1
+            let op = opFromToken(token.element)
+            guard let right = parseAtom(&context) else { break }
+            node = BinaryOperationNode(op: op, left: node, right: right)
+        }
+        return node
+    }
+
+    private static func parseAtom(_ context: inout CodeConstructContext<FormulaNodeElement, FormulaTokenElement>) -> FormulaNodeBase? {
+        guard context.consuming < context.tokens.count,
+              let token = context.tokens[context.consuming] as? FormulaToken else { return nil }
+        switch token.element {
+        case .number:
+            context.consuming += 1
+            return NumberNode(value: token.text)
+        case .identifier:
+            context.consuming += 1
+            return IdentifierNode(name: token.text)
+        case .command:
+            context.consuming += 1
+            var args: [FormulaNodeBase] = []
+            while context.consuming < context.tokens.count,
+                  let open = context.tokens[context.consuming] as? FormulaToken,
+                  open.element == .lbrace {
+                context.consuming += 1
+                if let arg = parseExpression(&context) { args.append(arg) }
+                if context.consuming < context.tokens.count,
+                   let close = context.tokens[context.consuming] as? FormulaToken,
+                   close.element == .rbrace {
+                    context.consuming += 1
+                }
+            }
+            return CommandNode(name: token.text, arguments: args)
+        case .lparen:
+            context.consuming += 1
+            let expr = parseExpression(&context)
+            if context.consuming < context.tokens.count,
+               let close = context.tokens[context.consuming] as? FormulaToken,
+               close.element == .rparen {
+                context.consuming += 1
+            }
+            if let expr = expr { return GroupNode(children: [expr]) } else { return nil }
+        case .lbrace:
+            context.consuming += 1
+            let expr = parseExpression(&context)
+            if context.consuming < context.tokens.count,
+               let close = context.tokens[context.consuming] as? FormulaToken,
+               close.element == .rbrace {
+                context.consuming += 1
+            }
+            if let expr = expr { return GroupNode(children: [expr]) } else { return nil }
+        default:
+            return nil
+        }
+    }
+
+    private static func opFromToken(_ element: FormulaTokenElement) -> BinaryOperator {
+        switch element {
+        case .plus: return .plus
+        case .minus: return .minus
+        case .star: return .times
+        case .slash: return .divide
+        case .caret: return .caret
+        case .underscore: return .underscore
+        case .equals: return .equals
+        default: return .plus
+        }
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaCommandTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaCommandTokenBuilder.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftParser
+
+public class FormulaCommandTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let start = context.consuming
+        guard context.source[start] == "\\" else { return false }
+        var index = context.source.index(after: start)
+        while index < context.source.endIndex && context.source[index].isLetter {
+            index = context.source.index(after: index)
+        }
+        context.consuming = index
+        let name = String(context.source[start..<index])
+        context.tokens.append(FormulaToken.command(name, at: start..<index))
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaDelimiterTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaDelimiterTokenBuilder.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftParser
+
+@preconcurrency
+public class FormulaDelimiterTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    @preconcurrency nonisolated(unsafe) static let mapping: [Character: FormulaTokenElement] = [
+        "(": .lparen,
+        ")": .rparen,
+        "{": .lbrace,
+        "}": .rbrace
+    ]
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let char = context.source[context.consuming]
+        guard let element = Self.mapping[char] else { return false }
+        let start = context.consuming
+        context.consuming = context.source.index(after: start)
+        context.tokens.append(FormulaToken.symbol(element, at: start..<context.consuming))
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaIdentifierTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaIdentifierTokenBuilder.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftParser
+
+public class FormulaIdentifierTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let start = context.consuming
+        var index = start
+        let char = context.source[index]
+        guard char.isLetter else { return false }
+        index = context.source.index(after: index)
+        while index < context.source.endIndex && context.source[index].isLetter {
+            index = context.source.index(after: index)
+        }
+        context.consuming = index
+        let text = String(context.source[start..<index])
+        context.tokens.append(FormulaToken.identifier(text, at: start..<index))
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaNumberTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaNumberTokenBuilder.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftParser
+
+public class FormulaNumberTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let start = context.consuming
+        var index = start
+        let char = context.source[index]
+        guard char.isNumber else { return false }
+        index = context.source.index(after: index)
+        while index < context.source.endIndex && context.source[index].isNumber {
+            index = context.source.index(after: index)
+        }
+        context.consuming = index
+        let text = String(context.source[start..<index])
+        context.tokens.append(FormulaToken.number(text, at: start..<index))
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaOperatorTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaOperatorTokenBuilder.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftParser
+
+@preconcurrency
+public class FormulaOperatorTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    @preconcurrency nonisolated(unsafe) static let mapping: [Character: FormulaTokenElement] = [
+        "+": .plus,
+        "-": .minus,
+        "*": .star,
+        "/": .slash,
+        "^": .caret,
+        "_": .underscore,
+        "=": .equals
+    ]
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        let char = context.source[context.consuming]
+        guard let element = Self.mapping[char] else { return false }
+        let start = context.consuming
+        context.consuming = context.source.index(after: start)
+        context.tokens.append(FormulaToken.symbol(element, at: start..<context.consuming))
+        return true
+    }
+}

--- a/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaWhitespaceTokenBuilder.swift
+++ b/Sources/SwiftParserShowCase/Code/Formula/Tokens/FormulaWhitespaceTokenBuilder.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftParser
+
+public class FormulaWhitespaceTokenBuilder: CodeTokenBuilder {
+    public typealias Token = FormulaTokenElement
+
+    public init() {}
+
+    public func build(from context: inout CodeTokenContext<FormulaTokenElement>) -> Bool {
+        guard context.consuming < context.source.endIndex else { return false }
+        if context.source[context.consuming].isWhitespace {
+            context.consuming = context.source.index(after: context.consuming)
+            return true
+        }
+        return false
+    }
+}

--- a/Tests/SwiftParserShowCaseTests/Formula/FormulaParserTests.swift
+++ b/Tests/SwiftParserShowCaseTests/Formula/FormulaParserTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SwiftParser
+@testable import SwiftParserShowCase
+
+final class FormulaParserTests: XCTestCase {
+    private var tokenizer: CodeTokenizer<FormulaTokenElement>!
+    private var parser: CodeParser<FormulaNodeElement, FormulaTokenElement>!
+    private var language: FormulaLanguage!
+
+    override func setUp() {
+        super.setUp()
+        language = FormulaLanguage()
+        let lang = language!
+        tokenizer = CodeTokenizer(
+            builders: lang.tokens,
+            state: lang.state,
+            eofTokenFactory: { range in lang.eofToken(at: range) }
+        )
+        parser = CodeParser(language: lang)
+    }
+
+    override func tearDown() {
+        tokenizer = nil
+        parser = nil
+        language = nil
+        super.tearDown()
+    }
+
+    func testTokenizeSimpleExpression() {
+        let (tokens, errors) = tokenizer.tokenize("x+1")
+        XCTAssertTrue(errors.isEmpty)
+        XCTAssertEqual(tokens.count, 4)
+        XCTAssertEqual(tokens[0].element, .identifier)
+        XCTAssertEqual(tokens[1].element, .plus)
+        XCTAssertEqual(tokens[2].element, .number)
+        XCTAssertEqual(tokens.last?.element, .eof)
+    }
+
+    func testParseSimpleExpression() {
+        let result = parser.parse("x+1", language: language)
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertEqual(result.root.children.count, 1)
+        let expr = result.root.children.first as? BinaryOperationNode
+        XCTAssertNotNil(expr)
+        XCTAssertEqual(expr?.op, .plus)
+        XCTAssertTrue(expr?.left is IdentifierNode)
+        XCTAssertTrue(expr?.right is NumberNode)
+    }
+
+    func testParseCommand() {
+        let result = parser.parse("\\frac{1}{2}", language: language)
+        XCTAssertTrue(result.errors.isEmpty)
+        XCTAssertEqual(result.root.children.count, 1)
+        let cmd = result.root.children.first as? CommandNode
+        XCTAssertNotNil(cmd)
+        XCTAssertEqual(cmd?.name, "\\frac")
+        XCTAssertEqual(cmd?.arguments.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a token set for TeX formulas
- create AST node types for numbers, identifiers, commands and binary operations
- implement a recursive descent parser in `FormulaNodeBuilder`
- provide tokenizer and parser tests for simple formulas

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_6880d8ffde408322b7904cf1d51cbbd7