### PR TITLE
Fix nested emphasis parsing for CommonMark compliance

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownInlineBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownInlineBuilder.swift
@@ -258,9 +258,11 @@ public class MarkdownInlineBuilder: CodeNodeBuilder {
   ) {
     var remaining = count
 
-    while remaining > 0, let openIdx = stack.lastIndex(where: { $0.marker == marker }) {
+    while remaining > 0,
+      let openIdx = stack.lastIndex(where: { $0.marker == marker && $0.count <= remaining })
+    {
       let open = stack.remove(at: openIdx)
-      var closeCount = min(open.count, remaining)
+      var closeCount = open.count
       if marker == .tilde {
         guard open.count >= 2 && remaining >= 2 else {
           stack.append(open)

--- a/Tests/CodeParserCollectionTests/Markdown/Builders/MarkdownInlineBuilderTests.swift
+++ b/Tests/CodeParserCollectionTests/Markdown/Builders/MarkdownInlineBuilderTests.swift
@@ -63,15 +63,32 @@ struct MarkdownInlineBuilderTests {
     let result = parser.parse(input, language: language)
 
     #expect(result.errors.isEmpty)
-    // Ensure parsing succeeded
+    #expect(result.root.children.count == 1)
     guard let para = result.root.children.first as? ParagraphNode else {
       Issue.record("Expected ParagraphNode")
       return
     }
-    #expect(para.children.count == 3)
-    #expect(para.children[0] is EmphasisNode)
-    #expect(para.children[1] is TextNode)
-    #expect(para.children[2] is TextNode)
+    #expect(para.children.count == 1)
+    guard let strong = para.children.first as? StrongNode else {
+      Issue.record("Expected StrongNode")
+      return
+    }
+    #expect(strong.children.count == 2)
+    if let text = strong.children.first as? TextNode {
+      #expect(text.content == "bold ")
+    } else {
+      Issue.record("Expected TextNode inside StrongNode")
+    }
+    guard let innerEmphasis = strong.children.last as? EmphasisNode else {
+      Issue.record("Expected nested EmphasisNode")
+      return
+    }
+    #expect(innerEmphasis.children.count == 1)
+    if let innerText = innerEmphasis.children.first as? TextNode {
+      #expect(innerText.content == "and italic")
+    } else {
+      Issue.record("Expected TextNode inside EmphasisNode")
+    }
   }
 
   @Test("Inline code parsing")


### PR DESCRIPTION
## Summary
- ensure delimiter runs only close matching open delimiters, allowing proper nested emphasis parsing
- update nested emphasis unit test to expect strong containing italic text

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6894c38d5d5c8322a00d017dfced6850