### PR TITLE
Fix exclamation handling in Markdown parser

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownInlineBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownInlineBuilder.swift
@@ -172,7 +172,21 @@ public class MarkdownInlineBuilder: CodeNodeBuilder {
       if let image = parseImage(&context) {
         nodes.append(image)
       } else {
-        nodes.append(TextNode(content: token.text))
+        let shouldMerge: Bool
+        if let lastIndex = nodes.indices.last,
+          let _ = nodes[lastIndex] as? TextNode,
+          !delimiters.contains(where: { $0.index == lastIndex })
+        {
+          shouldMerge = true
+        } else {
+          shouldMerge = false
+        }
+
+        if shouldMerge, let last = nodes.last as? TextNode {
+          last.content += token.text
+        } else {
+          nodes.append(TextNode(content: token.text))
+        }
         context.consuming += 1
       }
       return true

--- a/Tests/CodeParserCollectionTests/Markdown/Builders/MarkdownExclamationTests.swift
+++ b/Tests/CodeParserCollectionTests/Markdown/Builders/MarkdownExclamationTests.swift
@@ -1,0 +1,53 @@
+import Testing
+
+@testable import CodeParserCollection
+@testable import CodeParserCore
+
+@Suite("ExclamationTests")
+struct ExclamationTests {
+  private let parser: CodeParser<MarkdownNodeElement, MarkdownTokenElement>
+  private let language: MarkdownLanguage
+
+  init() {
+    language = MarkdownLanguage()
+    parser = CodeParser(language: language)
+  }
+
+  @Test("Exclamation in text")
+  func exclamationInText() {
+    let input = "Hello! Everyone"
+    let result = parser.parse(input, language: language)
+
+    #expect(result.errors.isEmpty)
+    #expect(result.root.children.count == 1)
+    guard let para = result.root.children.first as? ParagraphNode else {
+      Issue.record("Expected ParagraphNode")
+      return
+    }
+    #expect(para.children.count == 1)
+    if let text = para.children.first as? TextNode {
+      #expect(text.content == "Hello! Everyone")
+    } else {
+      Issue.record("Expected TextNode")
+    }
+  }
+
+  @Test("Exclamation in heading")
+  func exclamationInHeading() {
+    let input = "# This is a heading!"
+    let result = parser.parse(input, language: language)
+
+    #expect(result.errors.isEmpty)
+    #expect(result.root.children.count == 1)
+    guard let heading = result.root.children.first as? HeaderNode else {
+      Issue.record("Expected HeaderNode")
+      return
+    }
+    #expect(heading.children.count == 1)
+    if let text = heading.children.first as? TextNode {
+      #expect(text.content == "This is a heading!")
+    } else {
+      Issue.record("Expected TextNode inside HeaderNode")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- merge stray `!` tokens into surrounding text when not part of an image
- add regression tests for exclamation handling in text and headings

## Testing
- `swift test`
- `swift test --filter ExclamationTests`


------
https://chatgpt.com/codex/tasks/task_e_6894c61947a88322b194dedf4327bf7d