### PR TITLE
Add cross-platform CodeParserShowCase executable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
             name: "CodeParserCollection",
             targets: ["CodeParserCollection"]
         ),
+        .executable(
+            name: "CodeParserShowCase",
+            targets: ["CodeParserShowCase"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-format.git", from: "510.1.0")
@@ -29,6 +33,10 @@ let package = Package(
         ),
         .target(name: "CodeParserCollection",
             dependencies: ["CodeParserCore"]
+        ),
+        .executableTarget(
+            name: "CodeParserShowCase",
+            dependencies: []
         ),
         .testTarget(
             name: "CodeParserCoreTests",

--- a/Sources/CodeParserShowCase/CodeParserShowCase.swift
+++ b/Sources/CodeParserShowCase/CodeParserShowCase.swift
@@ -1,0 +1,26 @@
+#if canImport(SwiftUI)
+  import SwiftUI
+
+  @main
+  struct CodeParserShowCaseApp: App {
+    var body: some Scene {
+      WindowGroup {
+        ContentView()
+      }
+    }
+  }
+
+  struct ContentView: View {
+    var body: some View {
+      Text("Hello from CodeParserShowCase!")
+        .padding()
+    }
+  }
+#else
+  @main
+  struct CodeParserShowCase {
+    static func main() {
+      print("Hello from CodeParserShowCase!")
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary
- Add CodeParserShowCase executable product and target
- Implement conditional main that uses SwiftUI on platforms where available

## Testing
- `./format.sh`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6894d9e6c5e08322af040f0a6940ec54