### PR TITLE
Add Markdown block node builders

### DIFF
--- a/Sources/CodeParserCollection/Markdown/MarkdownLanguage.swift
+++ b/Sources/CodeParserCollection/Markdown/MarkdownLanguage.swift
@@ -24,7 +24,19 @@ public class MarkdownLanguage: CodeLanguage {
   ///   disabled.
   public init() {
     self.nodes = [
-
+      MarkdownBlankLineNodeBuilder(),
+      MarkdownThematicBreakNodeBuilder(),
+      MarkdownHeadingNodeBuilder(),
+      MarkdownBlockquoteNodeBuilder(),
+      MarkdownOrderedListNodeBuilder(),
+      MarkdownUnorderedListNodeBuilder(),
+      MarkdownCodeBlockNodeBuilder(),
+      MarkdownHTMLBlockNodeBuilder(),
+      MarkdownImageBlockNodeBuilder(),
+      MarkdownDefinitionNodeBuilder(),
+      MarkdownAdmonitionNodeBuilder(),
+      MarkdownParagraphNodeBuilder(),
+      MarkdownListItemNodeBuilder()
     ]
     self.tokens = [
       MarkdownNewlineTokenBuilder(),

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownAdmonitionNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownAdmonitionNodeBuilder.swift
@@ -1,0 +1,16 @@
+import CodeParserCore
+import Foundation
+
+/// Placeholder builder for admonition blocks (e.g., `!!! note`).
+/// Parsing for admonitions is not implemented in this phase.
+public struct MarkdownAdmonitionNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    return false
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlankLineNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlankLineNodeBuilder.swift
@@ -1,0 +1,34 @@
+import CodeParserCore
+import Foundation
+
+/// Builder recognizing blank lines consisting only of optional whitespace
+/// followed by a newline. Blank lines are used to terminate paragraphs and
+/// other block constructs.
+public struct MarkdownBlankLineNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+    guard current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .newline || tok.element == .hardbreak || tok.element == .eof
+    else { return false }
+    current += 1
+
+    context.current.append(CodeNode<Node>(element: .blankLine))
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockquoteNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockquoteNodeBuilder.swift
@@ -1,0 +1,60 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for Markdown block quotes, lines beginning with `>`.
+/// This implementation creates a `BlockquoteNode` containing a single
+/// paragraph node for the line content.
+public struct MarkdownBlockquoteNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip initial spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current < context.tokens.count,
+          let marker = context.tokens[current] as? MarkdownToken,
+          marker.element == .punctuation, marker.text == ">" else { return false }
+    current += 1
+
+    // Skip one optional space after '>'
+    if current < context.tokens.count,
+       let space = context.tokens[current] as? MarkdownToken,
+       space.element == .whitespaces {
+      current += 1
+    }
+
+    // Capture remainder of line as paragraph content
+    let contentStart = current
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element != .newline, tok.element != .hardbreak, tok.element != .eof {
+      current += 1
+    }
+    let contentEnd = current
+
+    let bqNode = BlockquoteNode()
+    if contentEnd > contentStart {
+      // Build paragraph node for content
+      let startToken = context.tokens[contentStart] as! MarkdownToken
+      let endToken = context.tokens[contentEnd - 1] as! MarkdownToken
+      let range = startToken.range.lowerBound..<endToken.range.upperBound
+      let para = ParagraphNode(range: range)
+      bqNode.append(para)
+    }
+    context.current.append(bqNode)
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownCodeBlockNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownCodeBlockNodeBuilder.swift
@@ -1,0 +1,90 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for fenced code blocks using backtick (```) or tilde (~~~)
+/// fences. This is a simplified implementation that does not handle
+/// indented code blocks or all edge cases from the specification.
+public struct MarkdownCodeBlockNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current < context.tokens.count,
+          let fenceToken = context.tokens[current] as? MarkdownToken,
+          fenceToken.element == .punctuation,
+          fenceToken.text == "`" || fenceToken.text == "~" else { return false }
+    let fenceChar = fenceToken.text
+    var fenceCount = 0
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .punctuation, tok.text == fenceChar {
+      fenceCount += 1
+      current += 1
+    }
+    guard fenceCount >= 3 else { return false }
+
+    // Optional info string (language) until newline
+    var language = ""
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element != .newline, tok.element != .hardbreak, tok.element != .eof {
+      language += tok.text
+      current += 1
+    }
+    if current < context.tokens.count { current += 1 } // consume newline
+
+    // Gather content until closing fence
+    var content = ""
+    var lineTokens: [MarkdownToken] = []
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .newline || tok.element == .hardbreak || tok.element == .eof {
+        // End of line: check if lineTokens represent closing fence
+        var i = 0
+        while i < lineTokens.count,
+              lineTokens[i].element == .whitespaces { i += 1 }
+        var closingCount = 0
+        while i < lineTokens.count,
+              lineTokens[i].element == .punctuation,
+              lineTokens[i].text == fenceChar {
+          closingCount += 1
+          i += 1
+        }
+        if closingCount >= fenceCount && i == lineTokens.count {
+          // reached closing fence
+          current += 1
+          break
+        } else {
+          // not closing fence: append lineTokens and newline to content
+          content += lineTokens.map { $0.text }.joined()
+          content += "\n"
+          lineTokens.removeAll()
+          current += 1
+          continue
+        }
+      } else {
+        lineTokens.append(tok)
+        current += 1
+      }
+    }
+
+    let node = CodeBlockNode(source: content, language: language.trimmingCharacters(in: .whitespaces))
+    context.current.append(node)
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownDefinitionNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownDefinitionNodeBuilder.swift
@@ -1,0 +1,17 @@
+import CodeParserCore
+import Foundation
+
+/// Placeholder builder for definition lists. Definition list support is not
+/// yet implemented, so this builder currently returns `false` and performs
+/// no parsing.
+public struct MarkdownDefinitionNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    return false
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHTMLBlockNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHTMLBlockNodeBuilder.swift
@@ -1,0 +1,56 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for HTML blocks starting with `<` and continuing until the end
+/// of the line. This is a naive implementation that does not attempt to
+/// match full HTML block rules from the specification.
+public struct MarkdownHTMLBlockNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current < context.tokens.count,
+          let lt = context.tokens[current] as? MarkdownToken,
+          lt.element == .punctuation, lt.text == "<" else { return false }
+    current += 1
+
+    // Capture tag name
+    var name = ""
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .characters {
+      name += tok.text
+      current += 1
+    }
+
+    // Capture rest of line as content including tag name
+    var content = "<" + name
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .newline || tok.element == .hardbreak || tok.element == .eof {
+        break
+      }
+      content += tok.text
+      current += 1
+    }
+
+    let node = HTMLBlockNode(name: name, content: content)
+    context.current.append(node)
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHeadingNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHeadingNodeBuilder.swift
@@ -1,0 +1,52 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for ATX Markdown headings using leading `#` characters.
+/// Setext headings are not yet supported.
+public struct MarkdownHeadingNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    var level = 0
+
+    while current < context.tokens.count {
+      guard let token = context.tokens[current] as? MarkdownToken else { break }
+      if token.element == .punctuation && token.text == "#" { level += 1; current += 1 }
+      else { break }
+    }
+    guard level > 0 && level <= 6 else { return false }
+
+    // Require a space after the marker (spec requirement)
+    if current < context.tokens.count, let token = context.tokens[current] as? MarkdownToken,
+       token.element == .whitespaces {
+      current += 1
+    } else { return false }
+
+    // Consume heading text until end of line
+    var end = current
+    while end < context.tokens.count {
+      guard let tok = context.tokens[end] as? MarkdownToken else { break }
+      if tok.element == .newline || tok.element == .hardbreak || tok.element == .eof { break }
+      end += 1
+    }
+    guard end > current else { return false }
+
+    // Compute range for completeness even though HeaderNode currently does not
+    // store source ranges.
+    let startToken = context.tokens[start] as! MarkdownToken
+    let endToken = context.tokens[end - 1] as! MarkdownToken
+    _ = startToken.range.lowerBound..<endToken.range.upperBound
+    let node = HeaderNode(level: level)
+    context.current.append(node)
+    context.consuming = end
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownImageBlockNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownImageBlockNodeBuilder.swift
@@ -1,0 +1,67 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for image blocks of the form `![alt](url)` on its own line.
+/// This is a simplified recognizer primarily for demonstration purposes.
+public struct MarkdownImageBlockNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current + 1 < context.tokens.count,
+          let bang = context.tokens[current] as? MarkdownToken,
+          let open = context.tokens[current + 1] as? MarkdownToken,
+          bang.element == .punctuation, bang.text == "!",
+          open.element == .punctuation, open.text == "[" else { return false }
+    current += 2
+
+    // Alt text
+    var alt = ""
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken {
+      if tok.element == .punctuation && tok.text == "]" { break }
+      alt += tok.text
+      current += 1
+    }
+    guard current < context.tokens.count,
+          let closeBracket = context.tokens[current] as? MarkdownToken,
+          closeBracket.element == .punctuation, closeBracket.text == "]" else { return false }
+    current += 1
+
+    guard current < context.tokens.count,
+          let openParen = context.tokens[current] as? MarkdownToken,
+          openParen.element == .punctuation, openParen.text == "(" else { return false }
+    current += 1
+
+    var url = ""
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken {
+      if tok.element == .punctuation && tok.text == ")" { break }
+      url += tok.text
+      current += 1
+    }
+    guard current < context.tokens.count,
+          let closeParen = context.tokens[current] as? MarkdownToken,
+          closeParen.element == .punctuation, closeParen.text == ")" else { return false }
+    current += 1
+
+    let node = ImageBlockNode(url: url, alt: alt)
+    context.current.append(node)
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownListItemNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownListItemNodeBuilder.swift
@@ -1,0 +1,18 @@
+import CodeParserCore
+import Foundation
+
+/// Placeholder builder for standalone list items. In the current phase the
+/// list builders create list items directly, so this builder simply returns
+/// `false`. It exists to satisfy the requirement that each block element has a
+/// corresponding builder.
+public struct MarkdownListItemNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    return false
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownOrderedListNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownOrderedListNodeBuilder.swift
@@ -1,0 +1,74 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for ordered list items like `1.` or `1)` followed by a space.
+/// Creates an `OrderedListNode` containing a single `ListItemNode` with a
+/// paragraph child for the line content.
+public struct MarkdownOrderedListNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    // Parse digits
+    var digits = ""
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .characters,
+          Int(tok.text) != nil {
+      digits.append(tok.text)
+      current += 1
+    }
+    guard !digits.isEmpty else { return false }
+
+    // Expect '.' or ')'
+    guard current < context.tokens.count,
+          let punct = context.tokens[current] as? MarkdownToken,
+          punct.element == .punctuation,
+          punct.text == "." || punct.text == ")" else { return false }
+    current += 1
+
+    // Require space
+    guard current < context.tokens.count,
+          let space = context.tokens[current] as? MarkdownToken,
+          space.element == .whitespaces else { return false }
+    current += 1
+
+    // Capture content
+    let contentStart = current
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element != .newline, tok.element != .hardbreak, tok.element != .eof {
+      current += 1
+    }
+    let contentEnd = current
+
+    let startNum = Int(digits) ?? 1
+    let list = OrderedListNode(start: startNum)
+    let item = ListItemNode(marker: digits)
+    if contentEnd > contentStart {
+      let startTok = context.tokens[contentStart] as! MarkdownToken
+      let endTok = context.tokens[contentEnd - 1] as! MarkdownToken
+      let range = startTok.range.lowerBound..<endTok.range.upperBound
+      let para = ParagraphNode(range: range)
+      item.append(para)
+    }
+    list.append(item)
+    context.current.append(list)
+    context.consuming = current
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownParagraphNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownParagraphNodeBuilder.swift
@@ -1,0 +1,67 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for Markdown paragraph blocks. Paragraphs are sequences of
+/// non-blank lines separated by one or more blank lines.
+public struct MarkdownParagraphNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  /// Parse a paragraph from the token stream. This follows the block
+  /// structure rules from the CommonMark specification: a paragraph starts
+  /// with a non-blank line and continues until a blank line or EOF.
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    // Save starting position
+    let startIndex = context.consuming
+    guard startIndex < context.tokens.count else { return false }
+
+    // Paragraph cannot start with a blank line
+    if isBlankLine(from: startIndex, in: context) { return false }
+
+    var current = startIndex
+    var endIndex = startIndex
+    var sawContent = false
+
+    while current < context.tokens.count {
+      guard let token = context.tokens[current] as? MarkdownToken else { break }
+      switch token.element {
+      case .newline, .hardbreak, .eof:
+        endIndex = current
+        current += 1
+        // Stop at first blank line
+        if isBlankLine(from: current, in: context) { break }
+      default:
+        sawContent = true
+        current += 1
+      }
+    }
+
+    guard sawContent else { return false }
+
+    // Compute range from first to last consumed token
+    let startToken = context.tokens[startIndex] as! MarkdownToken
+    let endToken = context.tokens[max(startIndex, endIndex - 1)] as! MarkdownToken
+    let range = startToken.range.lowerBound..<endToken.range.upperBound
+    let node = ParagraphNode(range: range)
+    context.current.append(node)
+    context.consuming = current
+    return true
+  }
+
+  /// Determine if the tokens starting at index represent a blank line.
+  private func isBlankLine(from index: Int, in context: CodeConstructContext<Node, Token>) -> Bool {
+    var i = index
+    while i < context.tokens.count {
+      guard let token = context.tokens[i] as? MarkdownToken else { return true }
+      if token.element == .newline || token.element == .hardbreak || token.element == .eof {
+        return true
+      }
+      if token.element != .whitespaces { return false }
+      i += 1
+    }
+    return true
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownThematicBreakNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownThematicBreakNodeBuilder.swift
@@ -1,0 +1,51 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for thematic breaks (horizontal rules) which are lines consisting
+/// of three or more `-`, `*`, or `_` characters possibly separated by spaces.
+public struct MarkdownThematicBreakNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current < context.tokens.count else { return false }
+
+    var marker: String?
+    var count = 0
+    var i = current
+    while i < context.tokens.count {
+      guard let tok = context.tokens[i] as? MarkdownToken else { break }
+      switch tok.element {
+      case .punctuation:
+        if marker == nil { marker = tok.text }
+        guard tok.text == marker && ["-", "*", "_"] .contains(tok.text) else { return false }
+        count += 1
+        i += 1
+      case .whitespaces:
+        i += 1
+      case .newline, .hardbreak, .eof:
+        // End of line
+        context.current.append(ThematicBreakNode())
+        context.consuming = i
+        return count >= 3
+      default:
+        return false
+      }
+    }
+    return false
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownUnorderedListNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownUnorderedListNodeBuilder.swift
@@ -1,0 +1,60 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for unordered lists using `-`, `*`, or `+` markers.
+/// Each invocation parses a single list item and wraps it in an
+/// `UnorderedListNode` if necessary.
+public struct MarkdownUnorderedListNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count else { return false }
+
+    var current = start
+    // Skip leading spaces
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element == .whitespaces {
+      current += 1
+    }
+
+    guard current < context.tokens.count,
+          let marker = context.tokens[current] as? MarkdownToken,
+          marker.element == .punctuation,
+          ["-", "*", "+"].contains(marker.text) else { return false }
+    current += 1
+
+    // Following space required
+    guard current < context.tokens.count,
+          let space = context.tokens[current] as? MarkdownToken,
+          space.element == .whitespaces else { return false }
+    current += 1
+
+    let contentStart = current
+    while current < context.tokens.count,
+          let tok = context.tokens[current] as? MarkdownToken,
+          tok.element != .newline, tok.element != .hardbreak, tok.element != .eof {
+      current += 1
+    }
+    let contentEnd = current
+
+    let list = UnorderedListNode()
+    let item = ListItemNode(marker: marker.text)
+    if contentEnd > contentStart {
+      let startTok = context.tokens[contentStart] as! MarkdownToken
+      let endTok = context.tokens[contentEnd - 1] as! MarkdownToken
+      let range = startTok.range.lowerBound..<endTok.range.upperBound
+      let para = ParagraphNode(range: range)
+      item.append(para)
+    }
+    list.append(item)
+    context.current.append(list)
+    context.consuming = current
+    return true
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement Markdown block-level node builders for paragraphs, headings, thematic breaks, lists, blockquotes, code blocks, and others
- register new builders in `MarkdownLanguage`
- consolidate definition-related placeholders into `MarkdownDefinitionNodeBuilder`
- prefix all Markdown node builders with a `Markdown` naming prefix

## Testing
- `swift build`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a28eab0832290e569a40a140db8