### PR TITLE
Add Markdown inline node builders

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownCodeNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownCodeNodeBuilder.swift
@@ -1,0 +1,32 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline code spans using backtick delimiters.
+public struct MarkdownCodeNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count,
+          let token = context.tokens[start] as? MarkdownToken,
+          token.element == .punctuation, token.text == "`" else { return false }
+
+    var current = start + 1
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == "`" {
+        let slice = context.tokens[(start + 1)..<current]
+        let code = tokensToString(slice)
+        let node = CodeSpanNode(code: code)
+        context.current.append(node)
+        context.consuming = current + 1
+        return true
+      }
+      current += 1
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownEmphasisNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownEmphasisNodeBuilder.swift
@@ -1,0 +1,37 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline emphasis using * or _ delimiters.
+public struct MarkdownEmphasisNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count,
+          let token = context.tokens[start] as? MarkdownToken,
+          token.element == .punctuation,
+          token.text == "*" || token.text == "_" else { return false }
+    let delimiter = token.text
+    var current = start + 1
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == delimiter {
+        let slice = context.tokens[(start + 1)..<current]
+        let content = tokensToString(slice)
+        let emphasis = EmphasisNode(content: content)
+        // Append inner text as child
+        if !content.isEmpty {
+          emphasis.append(TextNode(content: content))
+        }
+        context.current.append(emphasis)
+        context.consuming = current + 1
+        return true
+      }
+      current += 1
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHTMLNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHTMLNodeBuilder.swift
@@ -1,0 +1,31 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline HTML segments enclosed in < and >.
+public struct MarkdownHTMLNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count,
+          let open = context.tokens[start] as? MarkdownToken,
+          open.element == .punctuation, open.text == "<" else { return false }
+    var current = start + 1
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == ">" {
+        let slice = context.tokens[start...current]
+        let content = tokensToString(slice)
+        let html = HTMLNode(content: content)
+        context.current.append(html)
+        context.consuming = current + 1
+        return true
+      }
+      current += 1
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownImageNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownImageNodeBuilder.swift
@@ -1,0 +1,50 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline images of the form ![alt](url).
+public struct MarkdownImageNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start + 1 < context.tokens.count,
+          let bang = context.tokens[start] as? MarkdownToken,
+          let open = context.tokens[start + 1] as? MarkdownToken,
+          bang.element == .punctuation, bang.text == "!",
+          open.element == .punctuation, open.text == "[" else { return false }
+    var current = start + 2
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == "]" { break }
+      current += 1
+    }
+    guard current < context.tokens.count,
+          let close = context.tokens[current] as? MarkdownToken,
+          close.element == .punctuation, close.text == "]" else { return false }
+    let altSlice = context.tokens[(start + 2)..<current]
+    let altText = tokensToString(altSlice)
+    var idx = current + 1
+    guard idx < context.tokens.count,
+          let lpar = context.tokens[idx] as? MarkdownToken,
+          lpar.element == .punctuation, lpar.text == "(" else { return false }
+    idx += 1
+    var urlEnd = idx
+    while urlEnd < context.tokens.count {
+      guard let tok = context.tokens[urlEnd] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == ")" { break }
+      urlEnd += 1
+    }
+    guard urlEnd < context.tokens.count,
+          let rpar = context.tokens[urlEnd] as? MarkdownToken,
+          rpar.element == .punctuation, rpar.text == ")" else { return false }
+    let urlSlice = context.tokens[idx..<urlEnd]
+    let url = tokensToString(urlSlice)
+    let image = ImageNode(url: url, alt: altText, title: "")
+    context.current.append(image)
+    context.consuming = urlEnd + 1
+    return true
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownLineBreakNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownLineBreakNodeBuilder.swift
@@ -1,0 +1,29 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for Markdown soft and hard line breaks.
+public struct MarkdownLineBreakNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    guard context.consuming < context.tokens.count,
+          let token = context.tokens[context.consuming] as? MarkdownToken else { return false }
+    switch token.element {
+    case .newline:
+      let node = LineBreakNode(variant: .soft)
+      context.current.append(node)
+      context.consuming += 1
+      return true
+    case .hardbreak:
+      let node = LineBreakNode(variant: .hard)
+      context.current.append(node)
+      context.consuming += 1
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownLinkNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownLinkNodeBuilder.swift
@@ -1,0 +1,51 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline links of the form [text](url).
+public struct MarkdownLinkNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count,
+          let open = context.tokens[start] as? MarkdownToken,
+          open.element == .punctuation, open.text == "[" else { return false }
+    var current = start + 1
+    while current < context.tokens.count {
+      guard let tok = context.tokens[current] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == "]" { break }
+      current += 1
+    }
+    guard current < context.tokens.count,
+          let close = context.tokens[current] as? MarkdownToken,
+          close.element == .punctuation, close.text == "]" else { return false }
+    let textSlice = context.tokens[(start + 1)..<current]
+    let linkText = tokensToString(textSlice)
+    var idx = current + 1
+    guard idx < context.tokens.count,
+          let lpar = context.tokens[idx] as? MarkdownToken,
+          lpar.element == .punctuation, lpar.text == "(" else { return false }
+    idx += 1
+    var urlEnd = idx
+    while urlEnd < context.tokens.count {
+      guard let tok = context.tokens[urlEnd] as? MarkdownToken else { break }
+      if tok.element == .punctuation && tok.text == ")" { break }
+      urlEnd += 1
+    }
+    guard urlEnd < context.tokens.count,
+          let rpar = context.tokens[urlEnd] as? MarkdownToken,
+          rpar.element == .punctuation, rpar.text == ")" else { return false }
+    let urlSlice = context.tokens[idx..<urlEnd]
+    let url = tokensToString(urlSlice)
+    let link = LinkNode(url: url, title: "")
+    if !linkText.isEmpty {
+      link.append(TextNode(content: linkText))
+    }
+    context.current.append(link)
+    context.consuming = urlEnd + 1
+    return true
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownStrikeNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownStrikeNodeBuilder.swift
@@ -1,0 +1,38 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for strikethrough using ~~ delimiters.
+public struct MarkdownStrikeNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start + 1 < context.tokens.count,
+          let first = context.tokens[start] as? MarkdownToken,
+          let second = context.tokens[start + 1] as? MarkdownToken,
+          first.element == .punctuation,
+          second.element == .punctuation,
+          first.text == "~", second.text == "~" else { return false }
+    var current = start + 2
+    while current + 1 < context.tokens.count {
+      guard let tok1 = context.tokens[current] as? MarkdownToken,
+            let tok2 = context.tokens[current + 1] as? MarkdownToken else { break }
+      if tok1.element == .punctuation && tok2.element == .punctuation && tok1.text == "~" && tok2.text == "~" {
+        let slice = context.tokens[(start + 2)..<current]
+        let content = tokensToString(slice)
+        let strike = StrikeNode(content: content)
+        if !content.isEmpty {
+          strike.append(TextNode(content: content))
+        }
+        context.current.append(strike)
+        context.consuming = current + 2
+        return true
+      }
+      current += 1
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownStrongNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownStrongNodeBuilder.swift
@@ -1,0 +1,40 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for inline strong emphasis using ** or __ delimiters.
+public struct MarkdownStrongNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start + 1 < context.tokens.count,
+          let first = context.tokens[start] as? MarkdownToken,
+          let second = context.tokens[start + 1] as? MarkdownToken,
+          first.element == .punctuation,
+          second.element == .punctuation,
+          first.text == second.text,
+          (first.text == "*" || first.text == "_") else { return false }
+    let delimiter = first.text
+    var current = start + 2
+    while current + 1 < context.tokens.count {
+      guard let tok1 = context.tokens[current] as? MarkdownToken,
+            let tok2 = context.tokens[current + 1] as? MarkdownToken else { break }
+      if tok1.element == .punctuation && tok2.element == .punctuation && tok1.text == delimiter && tok2.text == delimiter {
+        let slice = context.tokens[(start + 2)..<current]
+        let content = tokensToString(slice)
+        let strong = StrongNode(content: content)
+        if !content.isEmpty {
+          strong.append(TextNode(content: content))
+        }
+        context.current.append(strong)
+        context.consuming = current + 2
+        return true
+      }
+      current += 1
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownTextNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownTextNodeBuilder.swift
@@ -1,0 +1,40 @@
+import CodeParserCore
+import Foundation
+
+/// Builder for Markdown text inline elements.
+/// Collects contiguous character, whitespace, punctuation, or entity tokens
+/// and emits a single TextNode.
+public struct MarkdownTextNodeBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  public init() {}
+
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let start = context.consuming
+    guard start < context.tokens.count,
+          let token = context.tokens[start] as? MarkdownToken else { return false }
+
+    switch token.element {
+    case .characters, .whitespaces, .punctuation, .charef:
+      var current = start
+      outer: while current < context.tokens.count {
+        guard let tok = context.tokens[current] as? MarkdownToken else { break }
+        switch tok.element {
+        case .characters, .whitespaces, .punctuation, .charef:
+          current += 1
+        default:
+          break outer
+        }
+      }
+      let slice = context.tokens[start..<current]
+      let content = tokensToString(slice)
+      let node = TextNode(content: content)
+      context.current.append(node)
+      context.consuming = current
+      return true
+    default:
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add CodeNodeBuilder implementations for Markdown inline elements
- support parsing for text, emphasis, strong, strikethrough, code spans, links, images, HTML, and line breaks

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a5368ba7cc8322886a9d7f08cbbb7b