### PR TITLE
Centralize inline Markdown parsing with MarkdownContentBuilder

### DIFF
--- a/Sources/CodeParserCollection/Markdown/MarkdownLanguage.swift
+++ b/Sources/CodeParserCollection/Markdown/MarkdownLanguage.swift
@@ -23,27 +23,28 @@ public class MarkdownLanguage: CodeLanguage {
   ///   document AST. Passing a custom set allows features to be enabled or
   ///   disabled.
   public init() {
+    let contentBuilder = MarkdownContentBuilder()
     self.nodes = [
       MarkdownBlankLineNodeBuilder(),
       MarkdownThematicBreakNodeBuilder(),
-      MarkdownHeadingNodeBuilder(),
-      MarkdownBlockquoteNodeBuilder(),
-      MarkdownOrderedListNodeBuilder(),
-      MarkdownUnorderedListNodeBuilder(),
+      MarkdownHeadingNodeBuilder(contentBuilder: contentBuilder),
+      MarkdownBlockquoteNodeBuilder(contentBuilder: contentBuilder),
+      MarkdownOrderedListNodeBuilder(contentBuilder: contentBuilder),
+      MarkdownUnorderedListNodeBuilder(contentBuilder: contentBuilder),
       MarkdownCodeBlockNodeBuilder(),
       MarkdownHTMLBlockNodeBuilder(),
       MarkdownImageBlockNodeBuilder(),
       MarkdownDefinitionNodeBuilder(),
       MarkdownAdmonitionNodeBuilder(),
-      MarkdownParagraphNodeBuilder(),
-      MarkdownListItemNodeBuilder()
+      MarkdownParagraphNodeBuilder(contentBuilder: contentBuilder),
+      MarkdownListItemNodeBuilder(),
     ]
     self.tokens = [
       MarkdownNewlineTokenBuilder(),
       MarkdownWhitespaceTokenBuilder(),
       MarkdownEntitiesTokenBuilder(),
       MarkdownCharactersTokenBuilder(),
-      MarkdownPunctuationTokenBuilder()
+      MarkdownPunctuationTokenBuilder(),
     ]
   }
 

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownContentBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownContentBuilder.swift
@@ -1,0 +1,64 @@
+import CodeParserCore
+import Foundation
+
+/// Builder that parses inline Markdown content by delegating to a set of
+/// specialized inline node builders.
+///
+/// This centralizes inline parsing so that block-level builders can simply
+/// provide the tokens that make up their textual content and rely on this
+/// builder for dispatch and state management.
+public struct MarkdownContentBuilder: CodeNodeBuilder {
+  public typealias Node = MarkdownNodeElement
+  public typealias Token = MarkdownTokenElement
+
+  /// Ordered list of inline builders to run when parsing content.
+  private let builders: [any CodeNodeBuilder<Node, Token>]
+
+  public init(
+    builders: [any CodeNodeBuilder<Node, Token>] = [
+      MarkdownHTMLNodeBuilder(),
+      MarkdownStrikeNodeBuilder(),
+      MarkdownStrongNodeBuilder(),
+      MarkdownImageNodeBuilder(),
+      MarkdownCodeNodeBuilder(),
+      MarkdownLineBreakNodeBuilder(),
+      MarkdownLinkNodeBuilder(),
+      MarkdownEmphasisNodeBuilder(),
+      MarkdownTextNodeBuilder(),
+    ]
+  ) {
+    self.builders = builders
+  }
+
+  /// Parse all tokens in the provided context as inline content.
+  public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
+    let initial = context.consuming
+
+    while context.consuming < context.tokens.count {
+      var matched = false
+      for builder in builders {
+        let before = context.consuming
+        if builder.build(from: &context) {
+          matched = true
+          // Ensure progress to avoid infinite loops where a builder succeeds
+          // without consuming any tokens.
+          if context.consuming == before {
+            context.consuming += 1
+          }
+          break
+        }
+      }
+
+      if !matched {
+        let token = context.tokens[context.consuming]
+        context.errors.append(
+          CodeError("Unrecognized inline token: \(token.element)", range: token.range)
+        )
+        context.consuming += 1
+      }
+    }
+
+    return context.consuming > initial
+  }
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHeadingNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownHeadingNodeBuilder.swift
@@ -7,7 +7,11 @@ public struct MarkdownHeadingNodeBuilder: CodeNodeBuilder {
   public typealias Node = MarkdownNodeElement
   public typealias Token = MarkdownTokenElement
 
-  public init() {}
+  private let contentBuilder: MarkdownContentBuilder
+
+  public init(contentBuilder: MarkdownContentBuilder = MarkdownContentBuilder()) {
+    self.contentBuilder = contentBuilder
+  }
 
   public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
     let start = context.consuming
@@ -44,6 +48,12 @@ public struct MarkdownHeadingNodeBuilder: CodeNodeBuilder {
     let endToken = context.tokens[end - 1] as! MarkdownToken
     _ = startToken.range.lowerBound..<endToken.range.upperBound
     let node = HeaderNode(level: level)
+
+    let inlineTokens = Array(context.tokens[current..<end])
+    var inlineContext = CodeConstructContext(current: node, tokens: inlineTokens, state: context.state)
+    _ = contentBuilder.build(from: &inlineContext)
+    context.errors.append(contentsOf: inlineContext.errors)
+
     context.current.append(node)
     context.consuming = end
     return true

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownOrderedListNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownOrderedListNodeBuilder.swift
@@ -8,7 +8,11 @@ public struct MarkdownOrderedListNodeBuilder: CodeNodeBuilder {
   public typealias Node = MarkdownNodeElement
   public typealias Token = MarkdownTokenElement
 
-  public init() {}
+  private let contentBuilder: MarkdownContentBuilder
+
+  public init(contentBuilder: MarkdownContentBuilder = MarkdownContentBuilder()) {
+    self.contentBuilder = contentBuilder
+  }
 
   public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
     let start = context.consuming
@@ -63,6 +67,12 @@ public struct MarkdownOrderedListNodeBuilder: CodeNodeBuilder {
       let endTok = context.tokens[contentEnd - 1] as! MarkdownToken
       let range = startTok.range.lowerBound..<endTok.range.upperBound
       let para = ParagraphNode(range: range)
+
+      let inlineTokens = Array(context.tokens[contentStart..<contentEnd])
+      var inlineContext = CodeConstructContext(current: para, tokens: inlineTokens, state: context.state)
+      _ = contentBuilder.build(from: &inlineContext)
+      context.errors.append(contentsOf: inlineContext.errors)
+
       item.append(para)
     }
     list.append(item)

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownUnorderedListNodeBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownUnorderedListNodeBuilder.swift
@@ -8,7 +8,11 @@ public struct MarkdownUnorderedListNodeBuilder: CodeNodeBuilder {
   public typealias Node = MarkdownNodeElement
   public typealias Token = MarkdownTokenElement
 
-  public init() {}
+  private let contentBuilder: MarkdownContentBuilder
+
+  public init(contentBuilder: MarkdownContentBuilder = MarkdownContentBuilder()) {
+    self.contentBuilder = contentBuilder
+  }
 
   public func build(from context: inout CodeConstructContext<Node, Token>) -> Bool {
     let start = context.consuming
@@ -49,6 +53,12 @@ public struct MarkdownUnorderedListNodeBuilder: CodeNodeBuilder {
       let endTok = context.tokens[contentEnd - 1] as! MarkdownToken
       let range = startTok.range.lowerBound..<endTok.range.upperBound
       let para = ParagraphNode(range: range)
+
+      let inlineTokens = Array(context.tokens[contentStart..<contentEnd])
+      var inlineContext = CodeConstructContext(current: para, tokens: inlineTokens, state: context.state)
+      _ = contentBuilder.build(from: &inlineContext)
+      context.errors.append(contentsOf: inlineContext.errors)
+
       item.append(para)
     }
     list.append(item)


### PR DESCRIPTION
## Summary
- add `MarkdownContentBuilder` to coordinate inline node builders
- inject shared content builder into language and block-level node builders for inline parsing

## Testing
- `swift build`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68a5389b9d288322ab8d8088ee095b62