### PR TITLE
Implement setext heading resolution

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
@@ -30,6 +30,8 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
   public init() {
     self.resolvers = [
       .creation: [
+        MarkdownBlockquoteCreationResolver(),
+        MarkdownUnorderedListCreationResolver(),
         MarkdownSetextHeadingCreationResolver(),
         MarkdownThematicBreakCreationResolver(),
         MarkdownIndentedCodeBlockCreationResolver(),
@@ -37,6 +39,8 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
         MarkdownParagraphCreationResolver(),
       ],
       .continuation: [
+        MarkdownBlockquoteContinuationResolver(),
+        MarkdownUnorderedListContinuationResolver(),
         MarkdownThematicBreakContinuationResolver(),
         MarkdownIndentedCodeBlockContinuationResolver(),
         MarkdownATXHeadingContinuationResolver(),
@@ -44,6 +48,8 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
         MarkdownSetextHeadingContinuationResolver(),
       ],
       .construction: [
+        MarkdownBlockquoteConstructionResolver(),
+        MarkdownUnorderedListConstructionResolver(),
         MarkdownThematicBreakConstructionResolver(),
         MarkdownIndentedCodeBlockConstructionResolver(),
         MarkdownATXHeadingConstructionResolver(),

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownATXHeadingResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownATXHeadingResolvers.swift
@@ -7,6 +7,9 @@ public class MarkdownATXHeadingCreationResolver: MarkdownBlockResolver {
   public init() {}
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // ATX headings cannot start inside code blocks
+    guard context.current.element != .codeBlock else { return false }
+
     let tokens = context.tokens
     guard !tokens.isEmpty else { return false }
 

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownBlockquoteResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownBlockquoteResolvers.swift
@@ -1,0 +1,59 @@
+import CodeParserCore
+import Foundation
+
+/// Minimal blockquote resolvers supporting single-level blockquotes
+/// used in setext heading tests.
+public class MarkdownBlockquoteCreationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Do not start a blockquote within a code block
+    guard context.current.element != .codeBlock else { return false }
+    let tokens = context.tokens
+    let (depth, endIndex) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
+    guard depth > 0 else { return false }
+    guard let parent = context.current as? MarkdownNodeBase else { return false }
+    let bq = BlockquoteNode(level: depth)
+    parent.append(bq)
+    context.current = bq
+    // Yield remaining tokens to be processed inside blockquote
+    context.tokens = Array(tokens[endIndex...])
+    context.refreshed = true
+    return true
+  }
+}
+
+public class MarkdownBlockquoteContinuationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Only handle when current is a blockquote container
+    guard context.current.element == .blockquote else { return false }
+    let tokens = context.tokens
+    let (depth, endIndex) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
+    if depth > 0 {
+      // Consume one marker level and reprocess remaining tokens
+      context.tokens = Array(tokens[endIndex...])
+      context.refreshed = true
+      return true
+    }
+    // Blank lines keep the blockquote open
+    var isBlank = true
+    for t in tokens {
+      if t.element != .whitespaces && t.element != .newline && t.element != .eof {
+        isBlank = false
+        break
+      }
+    }
+    if isBlank { return true }
+    // Line without marker ends the blockquote
+    if let parent = context.current.parent {
+      context.current = parent
+      context.refreshed = true
+    }
+    return true
+  }
+}
+
+public class MarkdownBlockquoteConstructionResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool { return false }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
@@ -10,8 +10,8 @@ public class MarkdownIndentedCodeBlockCreationResolver: MarkdownBlockResolver {
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     let tokens = context.tokens
     var i = 0
-    // Do not start an indented code block inside a paragraph
-    guard context.current.element != .paragraph else { return false }
+    // Do not start an indented code block inside a paragraph or another code block
+    guard context.current.element != .paragraph, context.current.element != .codeBlock else { return false }
     guard i < tokens.count, tokens[i].element == .whitespaces else { return false }
     let ws = tokens[i].text
     let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
@@ -145,6 +145,13 @@ public class MarkdownInlineFinalizeResolver: MarkdownBlockResolver {
           i += 1
         }
       case .newline:
+        // If a line ends with a backslash and this newline is the final token,
+        // the backslash should be preserved literally (used in setext headings).
+        if textBuffer.hasSuffix("\\"), i + 1 == tokens.count {
+          // Do not produce a line break; keep the backslash
+          i += 1
+          continue
+        }
         // Decide hard vs soft line break
         // Hard break if textBuffer ends with a backslash (\\) or with two or more spaces
         let (isHardBreak, _): (Bool, Int) = {

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
@@ -1,0 +1,59 @@
+import CodeParserCore
+import Foundation
+
+/// Minimal unordered list resolvers needed for setext heading tests.
+public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Lists should not start inside code blocks or paragraphs already handled
+    guard context.current.element != .codeBlock else { return false }
+    let tokens = context.tokens
+    var i = 0
+    // Up to three leading spaces
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      let ws = tokens[i].text
+      let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      if spaceCount > 3 { return false }
+      i += 1
+    }
+    guard i < tokens.count else { return false }
+    let t = tokens[i]
+    guard t.element == .punctuation, t.text == "-" || t.text == "*" || t.text == "+" else { return false }
+    let marker = t.text
+    i += 1
+    // Require at least one space or end of line after marker
+    if i >= tokens.count { return false }
+    let next = tokens[i]
+    if next.element == .whitespaces { i += 1 }
+    else if next.element != .newline && next.element != .eof { return false }
+
+    // Ensure the line isn't an alternative thematic break like "* * *"
+    if i < tokens.count {
+      let after = tokens[i]
+      if after.element == .punctuation && (after.text == "-" || after.text == "*" || after.text == "+") {
+        return false
+      }
+    }
+
+    guard let parent = context.current as? MarkdownNodeBase else { return false }
+    let list = UnorderedListNode(level: 1, marker: marker)
+    parent.append(list)
+    let item = ListItemNode(marker: marker)
+    list.append(item)
+    context.current = item
+    // Yield remaining tokens (after marker and following space) for further processing
+    context.tokens = Array(tokens[i...])
+    context.refreshed = true
+    return true
+  }
+}
+
+public class MarkdownUnorderedListContinuationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool { return false }
+}
+
+public class MarkdownUnorderedListConstructionResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool { return false }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
@@ -7,6 +7,9 @@ public class MarkdownParagraphCreationResolver: MarkdownBlockResolver {
   public init() {}
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Paragraphs cannot start inside code blocks
+    guard context.current.element != .codeBlock else { return false }
+
     let tokens = context.tokens
     guard !isBlankLine(tokens) else { return false }
     // If line starts an ATX heading, let the heading resolver handle it.
@@ -37,6 +40,44 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
     if tokens.count == 1, tokens.first?.element == .eof { return false }
 
     // If this line is a thematic break, close the paragraph to allow interruption
+    // If this line is a setext underline, handle it before thematic breaks so
+    // that underline takes precedence when following a paragraph.
+    if isSetextUnderline(tokens) {
+      let (bqDepth, _) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
+      let level = MarkdownSetextUtils.headingLevel(for: tokens) ?? 0
+      if let parent = context.current.parent as? MarkdownNodeBase {
+        if parent.element == .blockquote, bqDepth == 0 {
+          if level == 2 {
+            // Dashes: end blockquote and reprocess outside
+            if let grand = parent.parent { context.current = grand } else { context.current = parent }
+            context.refreshed = true
+            return true
+          } else {
+            // Equals: keep inside blockquote as normal text
+            return true
+          }
+        }
+        if parent.element == .listItem {
+          // Underline without sufficient indent ends the list item and list
+          var leading = 0
+          if let t = tokens.first, t.element == .whitespaces {
+            leading = t.text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+          }
+          if leading < 4 {
+            if let list = parent.parent as? MarkdownNodeBase {
+              context.current = list.parent ?? list
+            } else {
+              context.current = parent.parent ?? parent
+            }
+            context.refreshed = true
+            return true
+          }
+        }
+      }
+      // Otherwise, keep paragraph open for heading transformation
+      return true
+    }
+
     if MarkdownThematicBreakUtils.isThematicBreakLine(tokens) {
       if let parent = context.current.parent as? MarkdownNodeBase {
         // If we're inside a blockquote and this line does not carry a '>' marker
@@ -62,23 +103,6 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
     let (bqDepth, _) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
     if bqDepth > 0 {
       if let parent = context.current.parent { context.current = parent }
-      return true
-    }
-
-    // If this line is a setext underline:
-    // - Do NOT end the paragraph here; leave it as current so the creation
-    //   resolver can transform it only when it immediately follows the paragraph.
-    // - Additionally, prevent transformation if we're inside a blockquote and the
-    //   line is a lazy continuation (no '>'): in that case, keep the paragraph
-    //   open so the underline is treated as literal text or other block (e.g. thematic break).
-    if isSetextUnderline(tokens) {
-      if let parent = context.current.parent as? MarkdownNodeBase, parent.element == .blockquote {
-        if bqDepth == 0 {
-          // Lazy continuation within blockquote: keep the paragraph open
-          return true
-        }
-      }
-      // Keep paragraph as current; creation resolver will handle transformation
       return true
     }
 
@@ -130,9 +154,16 @@ public class MarkdownParagraphConstructionResolver: MarkdownBlockResolver {
       }
     }
 
-    // Include all remaining tokens (including .newline/.eof) for inline processing
+    // Include all remaining tokens (including .newline/.eof) for inline processing.
+    // Rather than creating a new ContentNode per line, append the tokens to the
+    // last existing ContentNode so inline parsing can span across line breaks
+    // (needed for emphasis that crosses lines in setext headings).
     let contentTokens: [any CodeToken<MarkdownTokenElement>] = Array(tokens[i...])
-    paragraph.append(ContentNode(tokens: contentTokens))
+    if let last = paragraph.children.last as? ContentNode {
+      last.tokens.append(contentsOf: contentTokens)
+    } else {
+      paragraph.append(ContentNode(tokens: contentTokens))
+    }
     return true
   }
 }

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownSetextHeadingResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownSetextHeadingResolver.swift
@@ -13,29 +13,45 @@ public class MarkdownSetextHeadingCreationResolver: MarkdownBlockResolver {
 
     guard let level = MarkdownSetextUtils.headingLevel(for: tokens) else { return false }
 
-    // Find the last paragraph child in the current container
-    guard let container = context.current as? MarkdownNodeBase else { return false }
-    guard let lastIndex = container.children.lastIndex(where: { $0.element == .paragraph }),
-          let paragraph = container.children[lastIndex] as? MarkdownNodeBase else {
+    // Setext headings transform the _current_ paragraph. Ensure the
+    // current node is a paragraph and we have access to its parent
+    // container to perform the replacement.
+    guard
+      let paragraph = context.current as? MarkdownNodeBase,
+      paragraph.element == .paragraph,
+      let container = paragraph.parent as? MarkdownNodeBase,
+      let index = container.children.firstIndex(where: { $0 === paragraph })
+    else {
       return false
     }
 
-    // Transform paragraph -> heading(level)
+    // Do not transform if inside a blockquote where the underline line is a
+    // lazy continuation (i.e., the line lacks '>'). In that case the underline
+    // should be treated as regular text.
+    let (bqDepth, _) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
+    if container.element == .blockquote && bqDepth == 0 {
+      return false
+    }
+
+    // Create heading node with the detected level
     let heading = HeaderNode(level: level)
-    // Move children from paragraph to heading
-    let movedChildren = paragraph.children
+
+    // Move existing children from the paragraph to the new heading
+    let moved = paragraph.children
     paragraph.children.removeAll()
-    for child in movedChildren {
-      if let mChild = child as? MarkdownNodeBase {
-        heading.append(mChild)
+    for child in moved {
+      if let m = child as? MarkdownNodeBase {
+        heading.append(m)
       } else {
         heading.append(child)
       }
     }
-    // Replace paragraph with heading in container
-    container.replace(at: lastIndex, with: heading)
 
-    // Keep context.current at container (headings are single-line blocks)
+    // Replace the paragraph in its parent with the heading
+    container.replace(at: index, with: heading)
+
+    // After replacement, the current context should move back to the parent
+    context.current = container
     return true
   }
 

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownThematicBreakResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownThematicBreakResolver.swift
@@ -6,6 +6,9 @@ public class MarkdownThematicBreakCreationResolver: MarkdownBlockResolver {
   public init() {}
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Do not recognize thematic breaks inside code blocks
+    guard context.current.element != .codeBlock else { return false }
+
     let tokens = context.tokens
     var i = 0
 


### PR DESCRIPTION
## Summary
- Transform the current paragraph into a heading when a setext underline is detected
- Merge paragraph content across lines and prioritize setext underlines over thematic breaks
- Preserve trailing backslashes, guard block-level parsers inside code blocks, and add minimal blockquote/list support

## Testing
- `swift test --filter MarkdownSetextHeadingsTests`
- `swift test` *(fails: Markdown Autolinks Extension Tests - Spec 036, Markdown Blank Lines Tests - Spec 022, Markdown Links Tests - Spec 033, Markdown Link Reference Definitions Tests - Spec 020, Markdown Images Tests - Spec 034, Markdown Tables Extension Tests - Spec 023, Markdown List Items Tests - Spec 025, Markdown Lists Tests - Spec 027, Markdown Backslash Escapes Tests - Spec 028, Markdown Tabs Tests - Spec 006, Markdown Entity and Numeric Character References Tests - Spec 029, Markdown Indented Code Blocks Tests - Spec 017, Markdown Fenced Code Blocks Tests - Spec 018, Markdown Task List Items Extension Tests - Spec 026, Markdown Paragraphs Tests - Spec 021, Markdown HTML Blocks Tests - Spec 019, Markdown Emphasis and Strong Emphasis Tests - Spec 031)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f11a2b608322af422ec312963a0f