### PR TITLE
Improve paragraph and thematic break parsing

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
@@ -135,10 +135,18 @@ public class MarkdownInlineFinalizeResolver: MarkdownBlockResolver {
             i += 1
           }
         } else if t.text == "*" || t.text == "_" {
-          flushText()
           let ch = Character(t.text)
           let runLen = readRun(of: ch, from: i)
-          handleEmphasis(runChar: ch, runLen: runLen)
+          let prev = i > 0 ? tokens[i - 1] : nil
+          let next = i + runLen < tokens.count ? tokens[i + runLen] : nil
+          let prevIsWS = prev == nil || prev!.element == .whitespaces || prev!.element == .newline
+          let nextIsWS = next == nil || next!.element == .whitespaces || next!.element == .newline
+          if (ch == "_" && (prevIsWS || nextIsWS)) || (ch == "*" && prevIsWS && nextIsWS) {
+            textBuffer.append(String(repeating: ch, count: runLen))
+          } else {
+            flushText()
+            handleEmphasis(runChar: ch, runLen: runLen)
+          }
           i += runLen
         } else {
           textBuffer.append(t.text)

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
@@ -5,8 +5,8 @@ import Foundation
 public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
   public init() {}
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
-    // Lists should not start inside code blocks or paragraphs already handled
-    guard context.current.element != .codeBlock else { return false }
+    // Lists should not start inside code blocks or existing list items
+    guard context.current.element != .codeBlock, context.current.element != .listItem else { return false }
     let tokens = context.tokens
     var i = 0
     // Up to three leading spaces
@@ -27,17 +27,22 @@ public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
     if next.element == .whitespaces { i += 1 }
     else if next.element != .newline && next.element != .eof { return false }
 
-    // Ensure the line isn't an alternative thematic break like "* * *"
+    // Ensure the line isn't an alternative thematic break like "- - -" or "* * *"
     if i < tokens.count {
       let after = tokens[i]
-      if after.element == .punctuation && (after.text == "-" || after.text == "*" || after.text == "+") {
+      if after.element == .punctuation && after.text == marker {
         return false
       }
     }
 
     guard let parent = context.current as? MarkdownNodeBase else { return false }
-    let list = UnorderedListNode(level: 1, marker: marker)
-    parent.append(list)
+    let list: UnorderedListNode
+    if let existing = parent as? UnorderedListNode, existing.element == .unorderedList, existing.marker == marker {
+      list = existing
+    } else {
+      list = UnorderedListNode(level: 1, marker: marker)
+      parent.append(list)
+    }
     let item = ListItemNode(marker: marker)
     list.append(item)
     context.current = item

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
@@ -90,6 +90,13 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
           } else {
             context.current = parent
           }
+        } else if parent.element == .listItem {
+          // A thematic break interrupts the list item (and the list itself)
+          if let list = parent.parent as? MarkdownNodeBase {
+            context.current = list.parent ?? list
+          } else {
+            context.current = parent.parent ?? parent
+          }
         } else {
           context.current = parent
         }
@@ -99,10 +106,19 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
       return true
     }
 
-    // If next line starts a blockquote, end the paragraph to allow interruption
+    // If next line starts a blockquote or a new list item, end the paragraph to allow interruption
     let (bqDepth, _) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
     if bqDepth > 0 {
       if let parent = context.current.parent { context.current = parent }
+      return true
+    }
+    if MarkdownListUtils.startsWithAnyMarker(tokens: tokens) {
+      if let parent = context.current.parent as? MarkdownNodeBase, parent.element == .listItem {
+        context.current = parent.parent ?? parent
+      } else if let parent = context.current.parent {
+        context.current = parent
+      }
+      context.refreshed = true
       return true
     }
 
@@ -146,8 +162,8 @@ public class MarkdownParagraphConstructionResolver: MarkdownBlockResolver {
       let ws = tokens[i].text
       let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
       if hasPriorContent {
-        // For continuation lines, strip up to 4 spaces of indentation
-        if spaceCount <= 4 { i += 1 }
+        // For continuation lines, strip all leading indentation
+        i += 1
       } else {
         // For the first line, skip at most three spaces
         if spaceCount <= 3 { i += 1 }

--- a/Sources/CodeParserCollection/Markdown/Utils/MarkdownListUtils.swift
+++ b/Sources/CodeParserCollection/Markdown/Utils/MarkdownListUtils.swift
@@ -23,7 +23,12 @@ package enum MarkdownListUtils {
     let t = tokens[i]
     guard t.element == .punctuation, ["-", "*", "+"].contains(t.text) else { return nil }
     var next = i + 1
-    if next < tokens.count, tokens[next].element == .whitespaces { next += 1 }
+    if next >= tokens.count { return nil }
+    let nxt = tokens[next]
+    if nxt.element == .whitespaces { next += 1 }
+    else if nxt.element != .newline && nxt.element != .eof { return nil }
+    // Prevent misidentifying thematic breaks like "- - -" or "* * *" as list markers
+    if next < tokens.count, tokens[next].element == .punctuation, tokens[next].text == t.text { return nil }
     return UnorderedMarker(marker: t.text, nextIndex: next)
   }
 
@@ -39,7 +44,10 @@ package enum MarkdownListUtils {
     let j = i + 1
     guard j < tokens.count, tokens[j].element == .punctuation, [".", ")"].contains(tokens[j].text) else { return nil }
     var next = j + 1
-    if next < tokens.count, tokens[next].element == .whitespaces { next += 1 }
+    if next >= tokens.count { return nil }
+    let nxt = tokens[next]
+    if nxt.element == .whitespaces { next += 1 }
+    else if nxt.element != .newline && nxt.element != .eof { return nil }
     return OrderedMarker(numberText: t.text, delimiter: tokens[j].text, nextIndex: next)
   }
 


### PR DESCRIPTION
## Summary
- trim all leading indentation on continued paragraph lines
- close paragraphs when encountering thematic breaks or list markers
- refine list marker detection and reuse existing unordered lists
- prevent underscore runs near spaces from becoming emphasis

## Testing
- `swift test --filter MarkdownParagraphsTests`
- `swift test --filter MarkdownThematicBreaksTests`
- `swift test --filter MarkdownATXHeadingsTests`
- `swift test --filter MarkdownSetextHeadingsTests`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68c7705156a88322ab3e715fa57da5fa