### PR TITLE
Refine blockquote and code block handling

### DIFF
--- a/Sources/CodeParserCollection/Markdown/MarkdownNodes.swift
+++ b/Sources/CodeParserCollection/Markdown/MarkdownNodes.swift
@@ -231,6 +231,9 @@ public class CodeBlockNode: MarkdownNodeBase {
 
   // Package-level indentation properties for nested block parsing
   package var indent: Int = 0  // Number of spaces before the code block
+  // Fenced code block properties
+  package var fenceChar: Character?  // ` or ~ when parsed from fenced code
+  package var fenceCount: Int = 0    // number of fence characters defining the block
 
   public init(source: String, language: String? = nil) {
     self.language = language

--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
@@ -32,8 +32,10 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
       .creation: [
         MarkdownBlockquoteCreationResolver(),
         MarkdownUnorderedListCreationResolver(),
+        MarkdownOrderedListCreationResolver(),
         MarkdownSetextHeadingCreationResolver(),
         MarkdownThematicBreakCreationResolver(),
+        MarkdownFencedCodeBlockCreationResolver(),
         MarkdownIndentedCodeBlockCreationResolver(),
         MarkdownATXHeadingCreationResolver(),
         MarkdownParagraphCreationResolver(),
@@ -41,7 +43,9 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
       .continuation: [
         MarkdownBlockquoteContinuationResolver(),
         MarkdownUnorderedListContinuationResolver(),
+        MarkdownOrderedListContinuationResolver(),
         MarkdownThematicBreakContinuationResolver(),
+        MarkdownFencedCodeBlockContinuationResolver(),
         MarkdownIndentedCodeBlockContinuationResolver(),
         MarkdownATXHeadingContinuationResolver(),
         MarkdownParagraphContinuationResolver(),
@@ -50,7 +54,9 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
       .construction: [
         MarkdownBlockquoteConstructionResolver(),
         MarkdownUnorderedListConstructionResolver(),
+        MarkdownOrderedListConstructionResolver(),
         MarkdownThematicBreakConstructionResolver(),
+        MarkdownFencedCodeBlockConstructionResolver(),
         MarkdownIndentedCodeBlockConstructionResolver(),
         MarkdownATXHeadingConstructionResolver(),
         MarkdownParagraphConstructionResolver(),

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownBlockquoteResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownBlockquoteResolvers.swift
@@ -25,17 +25,38 @@ public class MarkdownBlockquoteCreationResolver: MarkdownBlockResolver {
 public class MarkdownBlockquoteContinuationResolver: MarkdownBlockResolver {
   public init() {}
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
-    // Only handle when current is a blockquote container
-    guard context.current.element == .blockquote else { return false }
+    // Handle when current is blockquote or its child
+    let inChild = context.current.element != .blockquote
+    if inChild {
+      guard context.current.parent?.element == .blockquote else { return false }
+    }
     let tokens = context.tokens
     let (depth, endIndex) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
     if depth > 0 {
-      // Consume one marker level and reprocess remaining tokens
+      // Strip blockquote markers and continue processing remaining tokens in
+      // the same iteration so other resolvers (like code blocks) can act on
+      // them.
       context.tokens = Array(tokens[endIndex...])
+      return false
+    }
+    if inChild {
+      // If the current child is a paragraph, allow lazy continuation without a
+      // '>' marker by keeping context unchanged so paragraph resolvers can
+      // process the line inside the blockquote.
+      if context.current.element == .paragraph {
+        return false
+      }
+      // Otherwise we're leaving the blockquote: pop to its parent so that
+      // subsequent resolvers see the line in the outer context (closing any
+      // nested constructs like fenced code blocks).
+      if let grand = context.current.parent?.parent {
+        context.current = grand
+      } else if let parent = context.current.parent {
+        context.current = parent
+      }
       context.refreshed = true
       return true
     }
-    // Blank lines keep the blockquote open
     var isBlank = true
     for t in tokens {
       if t.element != .whitespaces && t.element != .newline && t.element != .eof {
@@ -44,7 +65,6 @@ public class MarkdownBlockquoteContinuationResolver: MarkdownBlockResolver {
       }
     }
     if isBlank { return true }
-    // Line without marker ends the blockquote
     if let parent = context.current.parent {
       context.current = parent
       context.refreshed = true

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownFencedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownFencedCodeBlockResolvers.swift
@@ -1,0 +1,123 @@
+import CodeParserCore
+import Foundation
+
+// MARK: - Fenced Code Block Resolvers
+
+public class MarkdownFencedCodeBlockCreationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    // Do not start a fenced code block when already inside one
+    guard context.current.element != .codeBlock else { return false }
+    let tokens = context.tokens
+    var i = 0
+    var indent = 0
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      indent = tokens[i].text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      if indent > 3 { return false }
+      i += 1
+    }
+    guard i < tokens.count, tokens[i].element == .punctuation else { return false }
+    let fenceChar = tokens[i].text
+    guard fenceChar == "`" || fenceChar == "~" else { return false }
+    var fenceCount = 0
+    while i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == fenceChar {
+      fenceCount += 1
+      i += 1
+    }
+    guard fenceCount >= 3 else { return false }
+    var infoTokens: [any CodeToken<MarkdownTokenElement>] = []
+    while i < tokens.count {
+      let t = tokens[i]
+      if t.element == .newline || t.element == .eof { break }
+      infoTokens.append(t)
+      i += 1
+    }
+    if fenceChar == "`" {
+      for t in infoTokens where t.element == .punctuation && t.text.contains("`") { return false }
+    }
+    let info = infoTokens.map { $0.text }.joined()
+    let lang = info.split { $0 == " " || $0 == "\t" }.first.map(String.init)
+    guard let parent = context.current as? MarkdownNodeBase else { return false }
+    let code = CodeBlockNode(source: "", language: lang?.isEmpty == false ? lang : nil)
+    code.indent = indent
+    code.fenceChar = fenceChar.first
+    code.fenceCount = fenceCount
+    parent.append(code)
+    context.current = code
+    context.tokens = []
+    return true
+  }
+}
+
+public class MarkdownFencedCodeBlockContinuationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let code = context.current as? CodeBlockNode, let fenceChar = code.fenceChar else { return false }
+    let tokens = context.tokens
+    if tokens.count == 1, tokens.first?.element == .eof {
+      while code.source.hasSuffix("\n") { code.source.removeLast() }
+      if let parent = code.parent { context.current = parent }
+      return false
+    }
+    var i = 0
+    var indent = 0
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      indent = tokens[i].text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      if indent > 3 { return true }
+      i += 1
+    }
+    if i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == String(fenceChar) {
+      var run = 0
+      while i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == String(fenceChar) {
+        run += 1
+        i += 1
+      }
+      if run >= code.fenceCount {
+        var j = i
+        var onlySpace = true
+        while j < tokens.count {
+          let t = tokens[j]
+          if t.element == .newline || t.element == .eof { break }
+          if t.element != .whitespaces { onlySpace = false; break }
+          j += 1
+        }
+        if onlySpace {
+          if let parent = code.parent { context.current = parent }
+          context.tokens = []
+          return true
+        }
+      }
+    }
+    return true
+  }
+}
+
+public class MarkdownFencedCodeBlockConstructionResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let code = context.current as? CodeBlockNode, code.fenceChar != nil else { return false }
+    let tokens = context.tokens
+    var i = 0
+    var line = ""
+    var strip = code.indent
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      var rem = strip
+      for ch in tokens[i].text {
+        if ch == " " && rem > 0 { rem -= 1; continue }
+        line.append(ch)
+      }
+      i += 1
+    }
+    while i < tokens.count {
+      let t = tokens[i]
+      if t.element == .newline {
+        line.append("\n")
+      } else if t.element != .eof {
+        line.append(t.text)
+      }
+      i += 1
+    }
+    code.source.append(line)
+    return true
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
@@ -10,8 +10,9 @@ public class MarkdownIndentedCodeBlockCreationResolver: MarkdownBlockResolver {
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     let tokens = context.tokens
     var i = 0
-    // Do not start an indented code block inside a paragraph or another code block
-    guard context.current.element != .paragraph, context.current.element != .codeBlock else { return false }
+    // Do not start an indented code block inside a paragraph, list item, or another code block
+    guard context.current.element != .paragraph, context.current.element != .listItem,
+          context.current.element != .codeBlock else { return false }
     guard i < tokens.count, tokens[i].element == .whitespaces else { return false }
     let ws = tokens[i].text
     let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
@@ -33,7 +34,13 @@ public class MarkdownIndentedCodeBlockContinuationResolver: MarkdownBlockResolve
     guard context.current.element == .codeBlock else { return false }
     let tokens = context.tokens
     if tokens.count == 1, tokens.first?.element == .eof {
-      // Nothing to do at EOF; leave as-is
+      if let code = context.current as? CodeBlockNode {
+        while code.source.hasSuffix("\n") { code.source.removeLast() }
+        if !code.source.isEmpty && !code.source.hasSuffix("```") && !code.source.hasSuffix("~~~") {
+          code.source.append("\n")
+        }
+      }
+      if let parent = context.current.parent { context.current = parent }
       return false
     }
     // Continue only if current line has >= 4 leading spaces or is blank
@@ -48,11 +55,13 @@ public class MarkdownIndentedCodeBlockContinuationResolver: MarkdownBlockResolve
     for t in tokens { if t.element != .whitespaces && t.element != .newline && t.element != .eof { isBlank = false; break } }
     if isBlank { return true }
 
-    // Otherwise, end the code block by trimming trailing newline and moving current to parent
-    if let code = context.current as? CodeBlockNode {
-      if code.source.hasSuffix("\n") {
-        code.source.removeLast()
-      }
+    // Otherwise, end the code block and move current to parent
+    var leading = 0
+    if let t = tokens.first, t.element == .whitespaces {
+      leading = t.text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+    }
+    if leading == 0, let code = context.current as? CodeBlockNode, code.source.hasSuffix("\n") {
+      code.source.removeLast()
     }
     if let parent = context.current.parent { context.current = parent }
     return true

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownInlineFinalizeResolver.swift
@@ -111,28 +111,41 @@ public class MarkdownInlineFinalizeResolver: MarkdownBlockResolver {
         i += 1
       case .punctuation:
         if t.text == "`" {
-          // Code span with single backticks (simplified); do not span across newline/EOF
           flushText()
-          var j = i + 1
+          let runLen = readRun(of: "`", from: i)
+          var j = i + runLen
           var code = String()
           var found = false
           while j < tokens.count {
             let tk = tokens[j]
-            if tk.element == .newline || tk.element == .eof { break }
-            if tk.element == .punctuation, tk.text == "`" {
-              found = true
-              break
+            if tk.element == .punctuation {
+              let closeRun = readRun(of: "`", from: j)
+              if closeRun >= runLen {
+                found = true
+                j += closeRun
+                break
+              }
             }
+            if tk.element == .newline {
+              code.append("\n")
+              j += 1
+              continue
+            }
+            if tk.element == .eof { break }
             code.append(tk.text)
             j += 1
           }
           if found {
-            nodes.append(CodeSpanNode(code: code))
-            i = j + 1
+            var content = code.replacingOccurrences(of: "\n", with: " ")
+            if content.count >= 2, content.first == " ", content.last == " " {
+              content.removeFirst()
+              content.removeLast()
+            }
+            nodes.append(CodeSpanNode(code: content))
+            i = j
           } else {
-            // No closing before newline/EOF; treat as literal backtick
-            textBuffer.append("`")
-            i += 1
+            textBuffer.append(String(repeating: "`", count: runLen))
+            i += runLen
           }
         } else if t.text == "*" || t.text == "_" {
           let ch = Character(t.text)

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
@@ -1,64 +1,177 @@
 import CodeParserCore
 import Foundation
 
-/// Minimal unordered list resolvers needed for setext heading tests.
+// MARK: - Unordered List Resolvers
+
 public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
   public init() {}
+
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
-    // Lists should not start inside code blocks or existing list items
-    guard context.current.element != .codeBlock, context.current.element != .listItem else { return false }
-    let tokens = context.tokens
-    var i = 0
-    // Up to three leading spaces
-    if i < tokens.count, tokens[i].element == .whitespaces {
-      let ws = tokens[i].text
-      let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
-      if spaceCount > 3 { return false }
-      i += 1
+    guard context.current.element != .codeBlock else { return false }
+    let allowIndented = ancestorListItem(from: context.current) != nil
+    guard let marker = MarkdownListUtils.detectUnorderedMarker(tokens: context.tokens, allowIndented: allowIndented) else { return false }
+    var cur = context.current
+    if cur.element == .paragraph, let p = cur.parent as? MarkdownNodeBase {
+      cur = p
+      context.current = p
     }
-    guard i < tokens.count else { return false }
-    let t = tokens[i]
-    guard t.element == .punctuation, t.text == "-" || t.text == "*" || t.text == "+" else { return false }
-    let marker = t.text
-    i += 1
-    // Require at least one space or end of line after marker
-    if i >= tokens.count { return false }
-    let next = tokens[i]
-    if next.element == .whitespaces { i += 1 }
-    else if next.element != .newline && next.element != .eof { return false }
-
-    // Ensure the line isn't an alternative thematic break like "- - -" or "* * *"
-    if i < tokens.count {
-      let after = tokens[i]
-      if after.element == .punctuation && after.text == marker {
-        return false
-      }
-    }
-
-    guard let parent = context.current as? MarkdownNodeBase else { return false }
-    let list: UnorderedListNode
-    if let existing = parent as? UnorderedListNode, existing.element == .unorderedList, existing.marker == marker {
-      list = existing
+    guard let parent = cur as? MarkdownNodeBase else { return false }
+    let level: Int
+    if let list = parent as? ListNode {
+      level = list.level
+    } else if let item = parent as? ListItemNode, let list = item.parent as? ListNode {
+      level = list.level + 1
     } else {
-      list = UnorderedListNode(level: 1, marker: marker)
-      parent.append(list)
+      level = 1
     }
-    let item = ListItemNode(marker: marker)
-    list.append(item)
+    let listNode = UnorderedListNode(level: level, marker: marker.marker)
+    parent.append(listNode)
+    let item = ListItemNode(marker: marker.marker)
+    listNode.append(item)
     context.current = item
-    // Yield remaining tokens (after marker and following space) for further processing
-    context.tokens = Array(tokens[i...])
-    context.refreshed = true
+    context.tokens = Array(context.tokens[marker.nextIndex...])
     return true
   }
 }
 
 public class MarkdownUnorderedListContinuationResolver: MarkdownBlockResolver {
   public init() {}
-  public func resolve(from context: inout MarkdownBlockContext) -> Bool { return false }
+
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let (list, _) = currentListContext(from: context.current) else { return false }
+    guard let marker = MarkdownListUtils.detectUnorderedMarker(tokens: context.tokens, allowIndented: true),
+          let ulist = list as? UnorderedListNode,
+          marker.marker == ulist.marker else { return false }
+    context.current = list
+    let newItem = ListItemNode(marker: marker.marker)
+    list.append(newItem)
+    context.current = newItem
+    context.tokens = Array(context.tokens[marker.nextIndex...])
+    return true
+  }
 }
 
 public class MarkdownUnorderedListConstructionResolver: MarkdownBlockResolver {
   public init() {}
-  public func resolve(from context: inout MarkdownBlockContext) -> Bool { return false }
+
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let item = context.current as? ListItemNode else { return false }
+    let tokens = context.tokens
+    if isBlankLine(tokens) { return true }
+    let paragraph: ParagraphNode
+    if let last = item.children.last as? ParagraphNode {
+      paragraph = last
+    } else {
+      let range = tokens.first?.range ?? tokens.last?.range ?? ("".startIndex..<("".startIndex))
+      paragraph = ParagraphNode(range: range)
+      item.append(paragraph)
+    }
+    paragraph.append(ContentNode(tokens: tokens))
+    context.current = paragraph
+    return true
+  }
 }
+
+// MARK: - Ordered List Resolvers
+
+public class MarkdownOrderedListCreationResolver: MarkdownBlockResolver {
+  public init() {}
+
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard context.current.element != .codeBlock else { return false }
+    let allowIndented = ancestorListItem(from: context.current) != nil
+    guard let info = MarkdownListUtils.detectOrderedMarker(tokens: context.tokens, allowIndented: allowIndented) else { return false }
+    var cur = context.current
+    if cur.element == .paragraph, let p = cur.parent as? MarkdownNodeBase {
+      cur = p
+      context.current = p
+    }
+    guard let parent = cur as? MarkdownNodeBase else { return false }
+    let level: Int
+    if let list = parent as? ListNode {
+      level = list.level
+    } else if let item = parent as? ListItemNode, let list = item.parent as? ListNode {
+      level = list.level + 1
+    } else {
+      level = 1
+    }
+    let start = Int(info.numberText) ?? 1
+    let listNode = OrderedListNode(start: start, level: level, delimiter: info.delimiter)
+    parent.append(listNode)
+    let item = ListItemNode(marker: info.numberText + info.delimiter)
+    listNode.append(item)
+    context.current = item
+    context.tokens = Array(context.tokens[info.nextIndex...])
+    return true
+  }
+}
+
+public class MarkdownOrderedListContinuationResolver: MarkdownBlockResolver {
+  public init() {}
+
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let (list, _) = currentListContext(from: context.current),
+          let olist = list as? OrderedListNode else { return false }
+    guard let info = MarkdownListUtils.detectOrderedMarker(tokens: context.tokens, allowIndented: true),
+          info.delimiter == olist.delimiter else { return false }
+    context.current = list
+    let item = ListItemNode(marker: info.numberText + info.delimiter)
+    list.append(item)
+    context.current = item
+    context.tokens = Array(context.tokens[info.nextIndex...])
+    return true
+  }
+}
+
+public class MarkdownOrderedListConstructionResolver: MarkdownBlockResolver {
+  public init() {}
+
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard let item = context.current as? ListItemNode else { return false }
+    let tokens = context.tokens
+    if isBlankLine(tokens) { return true }
+    let paragraph: ParagraphNode
+    if let last = item.children.last as? ParagraphNode {
+      paragraph = last
+    } else {
+      let range = tokens.first?.range ?? tokens.last?.range ?? ("".startIndex..<("".startIndex))
+      paragraph = ParagraphNode(range: range)
+      item.append(paragraph)
+    }
+    paragraph.append(ContentNode(tokens: tokens))
+    context.current = paragraph
+    return true
+  }
+}
+
+// MARK: - Helpers
+
+private func ancestorListItem(from node: CodeNode<MarkdownNodeElement>) -> ListItemNode? {
+  var cur = node as? MarkdownNodeBase
+  while let c = cur {
+    if let item = c as? ListItemNode { return item }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
+}
+
+private func currentListContext(from node: CodeNode<MarkdownNodeElement>) -> (ListNode, ListItemNode)? {
+  var cur = node as? MarkdownNodeBase
+  var foundItem: ListItemNode?
+  while let c = cur {
+    if foundItem == nil, let item = c as? ListItemNode { foundItem = item }
+    if let list = c as? ListNode, let item = foundItem { return (list, item) }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
+}
+
+private func isBlankLine(_ tokens: [any CodeToken<MarkdownTokenElement>]) -> Bool {
+  for t in tokens {
+    if t.element != .whitespaces && t.element != .newline && t.element != .eof {
+      return false
+    }
+  }
+  return true
+}
+

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
@@ -57,22 +57,6 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
             return true
           }
         }
-        if parent.element == .listItem {
-          // Underline without sufficient indent ends the list item and list
-          var leading = 0
-          if let t = tokens.first, t.element == .whitespaces {
-            leading = t.text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
-          }
-          if leading < 4 {
-            if let list = parent.parent as? MarkdownNodeBase {
-              context.current = list.parent ?? list
-            } else {
-              context.current = parent.parent ?? parent
-            }
-            context.refreshed = true
-            return true
-          }
-        }
       }
       // Otherwise, keep paragraph open for heading transformation
       return true
@@ -90,13 +74,6 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
           } else {
             context.current = parent
           }
-        } else if parent.element == .listItem {
-          // A thematic break interrupts the list item (and the list itself)
-          if let list = parent.parent as? MarkdownNodeBase {
-            context.current = list.parent ?? list
-          } else {
-            context.current = parent.parent ?? parent
-          }
         } else {
           context.current = parent
         }
@@ -106,18 +83,15 @@ public class MarkdownParagraphContinuationResolver: MarkdownBlockResolver {
       return true
     }
 
-    // If next line starts a blockquote or a new list item, end the paragraph to allow interruption
+    // If next line starts a blockquote, end the paragraph to allow interruption
     let (bqDepth, _) = MarkdownBlockquoteUtils.parseMarkers(in: tokens)
     if bqDepth > 0 {
       if let parent = context.current.parent { context.current = parent }
       return true
     }
-    if MarkdownListUtils.startsWithAnyMarker(tokens: tokens) {
-      if let parent = context.current.parent as? MarkdownNodeBase, parent.element == .listItem {
-        context.current = parent.parent ?? parent
-      } else if let parent = context.current.parent {
-        context.current = parent
-      }
+
+    if MarkdownFenceUtils.isFencedCodeFenceLine(tokens) {
+      if let parent = context.current.parent { context.current = parent }
       context.refreshed = true
       return true
     }
@@ -162,11 +136,13 @@ public class MarkdownParagraphConstructionResolver: MarkdownBlockResolver {
       let ws = tokens[i].text
       let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
       if hasPriorContent {
-        // For continuation lines, strip all leading indentation
         i += 1
       } else {
-        // For the first line, skip at most three spaces
-        if spaceCount <= 3 { i += 1 }
+        if let parent = paragraph.parent, parent.element == .listItem {
+          i += 1
+        } else if spaceCount <= 3 {
+          i += 1
+        }
       }
     }
 

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownSetextHeadingResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownSetextHeadingResolver.swift
@@ -32,6 +32,21 @@ public class MarkdownSetextHeadingCreationResolver: MarkdownBlockResolver {
     if container.element == .blockquote && bqDepth == 0 {
       return false
     }
+    if container.element == .listItem {
+      var leading = 0
+      if let t = tokens.first, t.element == .whitespaces {
+        leading = t.text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      }
+      if leading < 4 {
+        if let list = container.parent as? MarkdownNodeBase {
+          context.current = list.parent ?? list
+        } else {
+          context.current = container.parent ?? container
+        }
+        context.refreshed = true
+        return true
+      }
+    }
 
     // Create heading node with the detected level
     let heading = HeaderNode(level: level)

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownThematicBreakResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownThematicBreakResolver.swift
@@ -39,9 +39,31 @@ public class MarkdownThematicBreakCreationResolver: MarkdownBlockResolver {
     }
     guard count >= 3, marker != nil else { return false }
 
-    if let parent = context.current as? MarkdownNodeBase {
+    var target = context.current
+    // A thematic break interrupts a paragraph inside a list item, but can also
+    // appear as content of a list item. Pop out when we're in a paragraph within
+    // a list item or when the list item already has content (meaning the break
+    // should end the list).
+    if target.element == .paragraph, let p = target.parent, p.element == .listItem {
+      if let list = p.parent {
+        target = list.parent ?? list
+      } else {
+        target = p.parent ?? p
+      }
+      context.current = target
+    } else if target.element == .listItem,
+              let item = target as? MarkdownNodeBase, !item.children.isEmpty {
+      if let list = item.parent {
+        target = list.parent ?? list
+      } else {
+        target = item.parent ?? item
+      }
+      context.current = target
+    }
+    if let parent = target as? MarkdownNodeBase {
       parent.append(ThematicBreakNode())
-      // Remain at parent level (no child container)
+      // Consume the line so no further resolvers act on it
+      context.tokens = []
       return true
     }
     return false

--- a/Sources/CodeParserCollection/Markdown/Utils/MarkdownListUtils.swift
+++ b/Sources/CodeParserCollection/Markdown/Utils/MarkdownListUtils.swift
@@ -14,9 +14,9 @@ package enum MarkdownListUtils {
   }
 
   /// Detect unordered list marker at BOL (up to 3 leading spaces). Returns marker and index after marker+space.
-  package static func detectUnorderedMarker(tokens: [any CodeToken<MarkdownTokenElement>]) -> UnorderedMarker? {
+  package static func detectUnorderedMarker(tokens: [any CodeToken<MarkdownTokenElement>], allowIndented: Bool = false) -> UnorderedMarker? {
     let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
-    if leadingSpaces > 3 { return nil }
+    if !allowIndented && leadingSpaces > 3 { return nil }
     var i = 0
     while i < tokens.count && tokens[i].element == .whitespaces { i += 1 }
     guard i < tokens.count else { return nil }
@@ -33,9 +33,9 @@ package enum MarkdownListUtils {
   }
 
   /// Detect ordered list marker at BOL (up to 3 leading spaces). Returns number, delimiter, and index after marker.
-  package static func detectOrderedMarker(tokens: [any CodeToken<MarkdownTokenElement>]) -> OrderedMarker? {
+  package static func detectOrderedMarker(tokens: [any CodeToken<MarkdownTokenElement>], allowIndented: Bool = false) -> OrderedMarker? {
     let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
-    if leadingSpaces > 3 { return nil }
+    if !allowIndented && leadingSpaces > 3 { return nil }
     var i = 0
     while i < tokens.count && tokens[i].element == .whitespaces { i += 1 }
     guard i < tokens.count else { return nil }
@@ -52,8 +52,8 @@ package enum MarkdownListUtils {
   }
 
   /// Detect either unordered or ordered marker at BOL.
-  package static func startsWithAnyMarker(tokens: [any CodeToken<MarkdownTokenElement>]) -> Bool {
-    detectUnorderedMarker(tokens: tokens) != nil || detectOrderedMarker(tokens: tokens) != nil
+  package static func startsWithAnyMarker(tokens: [any CodeToken<MarkdownTokenElement>], allowIndented: Bool = false) -> Bool {
+    detectUnorderedMarker(tokens: tokens, allowIndented: allowIndented) != nil || detectOrderedMarker(tokens: tokens, allowIndented: allowIndented) != nil
   }
 }
 


### PR DESCRIPTION
## Summary
- move paragraph termination for list starts into list resolvers to uphold single-responsibility
- guard setext headings and thematic breaks from misinterpreting list items
- normalize indented code block newline retention based on following line indentation

## Testing
- `swift test --filter MarkdownIndentedCodeBlocksTests`
- `swift test --filter MarkdownFencedCodeBlocksTests`
- `swift test --filter MarkdownParagraphsTests`
- `swift test --filter MarkdownATXHeadingsTests`
- `swift test --filter MarkdownSetextHeadingsTests`
- `swift test --filter MarkdownThematicBreaksTests`


------
https://chatgpt.com/codex/tasks/task_e_68c77309ad508322bd061b917573cd7c