### PR TITLE
Improve list indent tracking in resolvers

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
@@ -10,16 +10,23 @@ public class MarkdownIndentedCodeBlockCreationResolver: MarkdownBlockResolver {
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     let tokens = context.tokens
     var i = 0
-    // Do not start an indented code block inside a paragraph, list item, or another code block
-    guard context.current.element != .paragraph, context.current.element != .listItem,
+    // Do not start an indented code block inside a paragraph or another code block
+    guard context.current.element != .paragraph,
           context.current.element != .codeBlock else { return false }
     guard i < tokens.count, tokens[i].element == .whitespaces else { return false }
     let ws = tokens[i].text
     let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
-    guard spaceCount >= 4 else { return false }
+    if let item = ancestorListItem(from: context.current) {
+      guard spaceCount >= item.contentIndent + 4 else { return false }
+    } else {
+      guard spaceCount >= 4 else { return false }
+    }
 
     if let parent = context.current as? MarkdownNodeBase {
       let code = CodeBlockNode(source: "")
+      if let item = ancestorListItem(from: parent) {
+        code.indent = item.contentIndent
+      }
       parent.append(code)
       context.current = code
       return true
@@ -43,12 +50,16 @@ public class MarkdownIndentedCodeBlockContinuationResolver: MarkdownBlockResolve
       if let parent = context.current.parent { context.current = parent }
       return false
     }
-    // Continue only if current line has >= 4 leading spaces or is blank
+    // Continue only if current line has required indentation or is blank
     var i = 0
     if i < tokens.count, tokens[i].element == .whitespaces {
       let ws = tokens[i].text
       let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
-      if spaceCount >= 4 { return true }
+      if let item = ancestorListItem(from: context.current) {
+        if spaceCount >= item.contentIndent + 4 { return true }
+      } else if spaceCount >= 4 {
+        return true
+      }
     }
     // Blank line continues the code block
     var isBlank = true
@@ -68,18 +79,32 @@ public class MarkdownIndentedCodeBlockContinuationResolver: MarkdownBlockResolve
   }
 }
 
+private func ancestorListItem(from node: CodeNode<MarkdownNodeElement>) -> ListItemNode? {
+  var cur = node as? MarkdownNodeBase
+  while let c = cur {
+    if let item = c as? ListItemNode { return item }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
+}
+
 public class MarkdownIndentedCodeBlockConstructionResolver: MarkdownBlockResolver {
   public init() {}
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     guard let code = context.current as? CodeBlockNode else { return false }
     let tokens = context.tokens
-    // Determine leading spaces to strip (up to 4)
+    // Determine leading spaces to strip: list item indent + 4, or up to 4 normally
     var i = 0
     var stripCount = 0
+    var base = 4
+    if let item = ancestorListItem(from: context.current) {
+      base = item.contentIndent + 4
+    }
     if i < tokens.count, tokens[i].element == .whitespaces {
       let ws = tokens[i].text
-      stripCount = min(4, ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) })
-      // Rebuild whitespace after stripping 4 spaces, if any remain
+      let spaceCount = ws.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      stripCount = min(base, spaceCount)
+      // Rebuild whitespace after stripping leading spaces, if any remain
     }
     var line = ""
     var remainingToStrip = stripCount

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownListResolvers.swift
@@ -1,6 +1,19 @@
 import CodeParserCore
 import Foundation
 
+private func whitespaceWidth(_ text: String) -> Int {
+  var width = 0
+  for ch in text {
+    if ch == "\t" {
+      let nextTab = ((width / 4) + 1) * 4
+      width = nextTab
+    } else {
+      width += 1
+    }
+  }
+  return width
+}
+
 // MARK: - Unordered List Resolvers
 
 public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
@@ -8,27 +21,53 @@ public class MarkdownUnorderedListCreationResolver: MarkdownBlockResolver {
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     guard context.current.element != .codeBlock else { return false }
+
+    if context.current.element == .paragraph, let item = ancestorListItem(from: context.current) {
+      let (spaces, _, _) = MarkdownIndentation.calculateIndentation(from: context.tokens)
+      if spaces < item.contentIndent && spaces - item.markerIndent <= 3 {
+        return false
+      }
+    }
+
     let allowIndented = ancestorListItem(from: context.current) != nil
-    guard let marker = MarkdownListUtils.detectUnorderedMarker(tokens: context.tokens, allowIndented: allowIndented) else { return false }
-    var cur = context.current
-    if cur.element == .paragraph, let p = cur.parent as? MarkdownNodeBase {
-      cur = p
+    guard
+      let marker = MarkdownListUtils.detectUnorderedMarker(
+        tokens: context.tokens, allowIndented: allowIndented)
+    else { return false }
+
+    let tokens = context.tokens
+    var markerIndex = 0
+    while markerIndex < tokens.count && tokens[markerIndex].element == .whitespaces {
+      markerIndex += 1
+    }
+    let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
+
+    // Adjust current node for paragraph or differing marker
+    if context.current.element == .paragraph, let p = context.current.parent as? MarkdownNodeBase {
       context.current = p
     }
-    guard let parent = cur as? MarkdownNodeBase else { return false }
-    let level: Int
-    if let list = parent as? ListNode {
-      level = list.level
-    } else if let item = parent as? ListItemNode, let list = item.parent as? ListNode {
-      level = list.level + 1
-    } else {
-      level = 1
+    if let list = context.current as? UnorderedListNode, list.marker != marker.marker,
+      let parent = list.parent as? MarkdownNodeBase
+    {
+      context.current = parent
     }
+
+    // Determine parent and level with shared indentation logic
+    guard let (resolvedParent, level) = determineListParent(&context, leadingSpaces: leadingSpaces)
+    else { return false }
+
     let listNode = UnorderedListNode(level: level, marker: marker.marker)
-    parent.append(listNode)
-    let item = ListItemNode(marker: marker.marker)
-    listNode.append(item)
-    context.current = item
+    resolvedParent.append(listNode)
+    let itemNode = ListItemNode(marker: marker.marker)
+    itemNode.markerIndent = leadingSpaces
+    let afterToken = markerIndex + 1 < tokens.count ? tokens[markerIndex + 1] : nil
+    let spacesAfter = (afterToken?.element == .whitespaces) ? whitespaceWidth(afterToken!.text) : 1
+    itemNode.contentIndent = leadingSpaces + 1 + spacesAfter
+    itemNode.markerColumn = leadingSpaces
+    itemNode.contentColumn = itemNode.contentIndent
+    itemNode.markerLength = 1
+    listNode.append(itemNode)
+    context.current = itemNode
     context.tokens = Array(context.tokens[marker.nextIndex...])
     return true
   }
@@ -38,12 +77,31 @@ public class MarkdownUnorderedListContinuationResolver: MarkdownBlockResolver {
   public init() {}
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
-    guard let (list, _) = currentListContext(from: context.current) else { return false }
-    guard let marker = MarkdownListUtils.detectUnorderedMarker(tokens: context.tokens, allowIndented: true),
-          let ulist = list as? UnorderedListNode,
-          marker.marker == ulist.marker else { return false }
+    guard let (list, item) = currentListContext(from: context.current) else { return false }
+
+    let tokens = context.tokens
+    let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
+    if leadingSpaces >= item.contentIndent { return false }
+    if leadingSpaces > 3 { return false }
+
+    guard let marker = MarkdownListUtils.detectUnorderedMarker(tokens: tokens, allowIndented: true),
+      let ulist = list as? UnorderedListNode,
+      marker.marker == ulist.marker
+    else { return false }
+
     context.current = list
     let newItem = ListItemNode(marker: marker.marker)
+    var markerIndex = 0
+    while markerIndex < tokens.count && tokens[markerIndex].element == .whitespaces {
+      markerIndex += 1
+    }
+    let afterToken = markerIndex + 1 < tokens.count ? tokens[markerIndex + 1] : nil
+    let spacesAfter = (afterToken?.element == .whitespaces) ? whitespaceWidth(afterToken!.text) : 1
+    newItem.markerIndent = leadingSpaces
+    newItem.contentIndent = leadingSpaces + 1 + spacesAfter
+    newItem.markerColumn = leadingSpaces
+    newItem.contentColumn = newItem.contentIndent
+    newItem.markerLength = 1
     list.append(newItem)
     context.current = newItem
     context.tokens = Array(context.tokens[marker.nextIndex...])
@@ -79,28 +137,62 @@ public class MarkdownOrderedListCreationResolver: MarkdownBlockResolver {
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
     guard context.current.element != .codeBlock else { return false }
+
+    if context.current.element == .paragraph, let item = ancestorListItem(from: context.current) {
+      let (spaces, _, _) = MarkdownIndentation.calculateIndentation(from: context.tokens)
+      if spaces < item.contentIndent && spaces - item.markerIndent <= 3 {
+        return false
+      }
+    }
+
     let allowIndented = ancestorListItem(from: context.current) != nil
-    guard let info = MarkdownListUtils.detectOrderedMarker(tokens: context.tokens, allowIndented: allowIndented) else { return false }
-    var cur = context.current
-    if cur.element == .paragraph, let p = cur.parent as? MarkdownNodeBase {
-      cur = p
+    guard
+      let info = MarkdownListUtils.detectOrderedMarker(
+        tokens: context.tokens, allowIndented: allowIndented)
+    else { return false }
+    if context.current.element == .paragraph && ancestorListItem(from: context.current) == nil
+      && info.numberText != "1"
+    {
+      return false
+    }
+
+    let tokens = context.tokens
+    var markerIndex = 0
+    while markerIndex < tokens.count && tokens[markerIndex].element == .whitespaces {
+      markerIndex += 1
+    }
+    let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
+    let startNumber = Int(info.numberText) ?? 1
+
+    // Adjust current node for paragraph or differing list characteristics
+    if context.current.element == .paragraph, let p = context.current.parent as? MarkdownNodeBase {
       context.current = p
     }
-    guard let parent = cur as? MarkdownNodeBase else { return false }
-    let level: Int
-    if let list = parent as? ListNode {
-      level = list.level
-    } else if let item = parent as? ListItemNode, let list = item.parent as? ListNode {
-      level = list.level + 1
-    } else {
-      level = 1
+    if let list = context.current as? OrderedListNode,
+      startNumber != list.start || info.delimiter != list.delimiter,
+      let parent = list.parent as? MarkdownNodeBase
+    {
+      context.current = parent
     }
-    let start = Int(info.numberText) ?? 1
+
+    // Determine parent and level with shared indentation logic
+    guard let (resolvedParent, level) = determineListParent(&context, leadingSpaces: leadingSpaces)
+    else { return false }
+
+    let start = startNumber
     let listNode = OrderedListNode(start: start, level: level, delimiter: info.delimiter)
-    parent.append(listNode)
-    let item = ListItemNode(marker: info.numberText + info.delimiter)
-    listNode.append(item)
-    context.current = item
+    resolvedParent.append(listNode)
+    let itemNode = ListItemNode(marker: info.numberText + info.delimiter)
+    let afterToken = markerIndex + 2 < tokens.count ? tokens[markerIndex + 2] : nil
+    let spacesAfter = (afterToken?.element == .whitespaces) ? whitespaceWidth(afterToken!.text) : 1
+    itemNode.markerIndent = leadingSpaces
+    itemNode.contentIndent =
+      leadingSpaces + info.numberText.count + info.delimiter.count + spacesAfter
+    itemNode.markerColumn = leadingSpaces
+    itemNode.contentColumn = itemNode.contentIndent
+    itemNode.markerLength = info.numberText.count + info.delimiter.count
+    listNode.append(itemNode)
+    context.current = itemNode
     context.tokens = Array(context.tokens[info.nextIndex...])
     return true
   }
@@ -110,14 +202,34 @@ public class MarkdownOrderedListContinuationResolver: MarkdownBlockResolver {
   public init() {}
 
   public func resolve(from context: inout MarkdownBlockContext) -> Bool {
-    guard let (list, _) = currentListContext(from: context.current),
-          let olist = list as? OrderedListNode else { return false }
-    guard let info = MarkdownListUtils.detectOrderedMarker(tokens: context.tokens, allowIndented: true),
-          info.delimiter == olist.delimiter else { return false }
+    guard let (list, item) = currentListContext(from: context.current),
+      let olist = list as? OrderedListNode
+    else { return false }
+
+    let tokens = context.tokens
+    let (leadingSpaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
+    if leadingSpaces >= item.contentIndent { return false }
+    if leadingSpaces > 3 { return false }
+
+    guard let info = MarkdownListUtils.detectOrderedMarker(tokens: tokens, allowIndented: true),
+      info.delimiter == olist.delimiter
+    else { return false }
     context.current = list
-    let item = ListItemNode(marker: info.numberText + info.delimiter)
-    list.append(item)
-    context.current = item
+    let newItem = ListItemNode(marker: info.numberText + info.delimiter)
+    var markerIndex = 0
+    while markerIndex < tokens.count && tokens[markerIndex].element == .whitespaces {
+      markerIndex += 1
+    }
+    let afterToken = markerIndex + 2 < tokens.count ? tokens[markerIndex + 2] : nil
+    let spacesAfter = (afterToken?.element == .whitespaces) ? whitespaceWidth(afterToken!.text) : 1
+    newItem.markerIndent = leadingSpaces
+    newItem.contentIndent =
+      leadingSpaces + info.numberText.count + info.delimiter.count + spacesAfter
+    newItem.markerColumn = leadingSpaces
+    newItem.contentColumn = newItem.contentIndent
+    newItem.markerLength = info.numberText.count + info.delimiter.count
+    list.append(newItem)
+    context.current = newItem
     context.tokens = Array(context.tokens[info.nextIndex...])
     return true
   }
@@ -155,7 +267,13 @@ private func ancestorListItem(from node: CodeNode<MarkdownNodeElement>) -> ListI
   return nil
 }
 
-private func currentListContext(from node: CodeNode<MarkdownNodeElement>) -> (ListNode, ListItemNode)? {
+private func currentListContext(from node: CodeNode<MarkdownNodeElement>) -> (
+  ListNode, ListItemNode
+)? {
+  // If node is a list, use its last item as context when available
+  if let list = node as? ListNode, let last = list.children.last as? ListItemNode {
+    return (list, last)
+  }
   var cur = node as? MarkdownNodeBase
   var foundItem: ListItemNode?
   while let c = cur {
@@ -175,3 +293,29 @@ private func isBlankLine(_ tokens: [any CodeToken<MarkdownTokenElement>]) -> Boo
   return true
 }
 
+// Shared helper to determine the parent node and resulting list level
+private func determineListParent(_ context: inout MarkdownBlockContext, leadingSpaces: Int) -> (
+  MarkdownNodeBase, Int
+)? {
+  let cur = context.current
+  var parent = cur as? MarkdownNodeBase
+  if let (list, item) = currentListContext(from: cur) {
+    if leadingSpaces >= item.contentIndent {
+      parent = item
+      context.current = item
+    } else {
+      parent = list
+      context.current = list
+    }
+  }
+  guard let resolved = parent else { return nil }
+  let level: Int
+  if let list = resolved as? ListNode {
+    level = list.level
+  } else if let item = resolved as? ListItemNode, let list = item.parent as? ListNode {
+    level = list.level + 1
+  } else {
+    level = 1
+  }
+  return (resolved, level)
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownParagraphResolvers.swift
@@ -12,6 +12,27 @@ public class MarkdownParagraphCreationResolver: MarkdownBlockResolver {
 
     let tokens = context.tokens
     guard !isBlankLine(tokens) else { return false }
+
+    // If we're inside a list item but the line's indentation is less than the
+    // item's content indentation, we may need to realign to the parent so that
+    // new list markers can be recognized. However, lazy continuation lines
+    // within existing paragraphs should remain attached to the current item.
+    if let item = nearestListItem(from: context.current) {
+      let (spaces, _, _) = MarkdownIndentation.calculateIndentation(from: tokens)
+      if spaces < item.contentIndent {
+        if MarkdownListUtils.startsWithAnyMarker(tokens: tokens, allowIndented: false) {
+          if let list = item.parent as? MarkdownNodeBase {
+            context.current = list
+          }
+          context.refreshed = true
+          return true
+        } else if context.current.element != .paragraph, let list = item.parent as? MarkdownNodeBase {
+          context.current = list.parent as? MarkdownNodeBase ?? list
+          context.refreshed = true
+          return true
+        }
+      }
+    }
     // If line starts an ATX heading, let the heading resolver handle it.
     if isATXStart(tokens) { return false }
     // Do not create a new paragraph if we're already inside one
@@ -126,8 +147,37 @@ public class MarkdownParagraphConstructionResolver: MarkdownBlockResolver {
       return false
     }
 
-    let tokens = context.tokens
+    var tokens = context.tokens
     guard !isBlankLine(tokens) else { return true }
+
+    if let item = paragraph.parent as? ListItemNode {
+      var spacesToStrip = item.contentIndent
+      var idx = 0
+      var stripped: [any CodeToken<MarkdownTokenElement>] = []
+      while spacesToStrip > 0, idx < tokens.count {
+        let t = tokens[idx]
+        if t.element == .whitespaces {
+          var remaining = ""
+          for ch in t.text {
+            if spacesToStrip > 0 {
+              spacesToStrip -= 1
+            } else {
+              remaining.append(ch)
+            }
+          }
+          if !remaining.isEmpty {
+            let range = t.range
+            let newToken = MarkdownToken(element: .whitespaces, text: remaining, range: range)
+            stripped.append(newToken)
+          }
+          idx += 1
+        } else {
+          break
+        }
+      }
+      stripped.append(contentsOf: tokens[idx...])
+      tokens = stripped
+    }
 
     var i = 0
     // Determine if this is a continued line within an existing paragraph
@@ -202,4 +252,13 @@ private func isSetextUnderline(_ tokens: [any CodeToken<MarkdownTokenElement>]) 
   }
 
   return MarkdownSetextUtils.headingLevel(for: tokens) != nil
+}
+
+private func nearestListItem(from node: CodeNode<MarkdownNodeElement>) -> ListItemNode? {
+  var cur = node as? MarkdownNodeBase
+  while let c = cur {
+    if let item = c as? ListItemNode { return item }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
 }


### PR DESCRIPTION
## Summary
- share indentation-aware parent resolution between ordered and unordered list creation
- centralize list level computation in `determineListParent` helper
- align ordered and unordered list creation on common indentation logic

## Testing
- `swift test --filter MarkdownListsTests --parallel` *(fails: 20 issues)*
- `swift test --filter MarkdownListItemsTests --parallel` *(fails: 26 issues)*
- `swift test --filter MarkdownIndentedCodeBlocksTests --parallel` *(fails: 2 issues)*
- `swift test --filter MarkdownFencedCodeBlocksTests --parallel`
- `swift test --filter MarkdownATXHeadingsTests --parallel`
- `swift test --filter MarkdownParagraphsTests --parallel`
- `swift test --filter MarkdownSetextHeadingsTests --parallel`
- `swift test --filter MarkdownThematicBreaksTests --parallel`


------
https://chatgpt.com/codex/tasks/task_e_68c7aab704848322ae6058aa07df28d5