### PR TITLE
Enhance Markdown list parsing with additional block resolvers

### DIFF
--- a/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/MarkdownBlockBuilder.swift
@@ -37,6 +37,8 @@ public class MarkdownBlockBuilder: CodeNodeBuilder {
         MarkdownThematicBreakCreationResolver(),
         MarkdownFencedCodeBlockCreationResolver(),
         MarkdownIndentedCodeBlockCreationResolver(),
+        MarkdownReferenceDefinitionResolver(),
+        MarkdownHTMLBlockCreationResolver(),
         MarkdownATXHeadingCreationResolver(),
         MarkdownParagraphCreationResolver(),
       ],

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownFencedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownFencedCodeBlockResolvers.swift
@@ -40,6 +40,9 @@ public class MarkdownFencedCodeBlockCreationResolver: MarkdownBlockResolver {
     guard let parent = context.current as? MarkdownNodeBase else { return false }
     let code = CodeBlockNode(source: "", language: lang?.isEmpty == false ? lang : nil)
     code.indent = indent
+    if let item = ancestorListItem(from: parent) {
+      code.indent += item.contentIndent
+    }
     code.fenceChar = fenceChar.first
     code.fenceCount = fenceCount
     parent.append(code)
@@ -47,6 +50,15 @@ public class MarkdownFencedCodeBlockCreationResolver: MarkdownBlockResolver {
     context.tokens = []
     return true
   }
+}
+
+private func ancestorListItem(from node: CodeNode<MarkdownNodeElement>) -> ListItemNode? {
+  var cur = node as? MarkdownNodeBase
+  while let c = cur {
+    if let item = c as? ListItemNode { return item }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
 }
 
 public class MarkdownFencedCodeBlockContinuationResolver: MarkdownBlockResolver {

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownHTMLBlockResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownHTMLBlockResolver.swift
@@ -1,0 +1,34 @@
+import CodeParserCore
+import Foundation
+
+public class MarkdownHTMLBlockCreationResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard context.current.element != .codeBlock else { return false }
+    let tokens = context.tokens
+    var i = 0
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      let spaces = tokens[i].text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      if spaces > 3 { return false }
+      i += 1
+    }
+    guard i + 3 < tokens.count else { return false }
+    guard tokens[i].element == .punctuation, tokens[i].text == "<" else { return false }
+    guard tokens[i+1].element == .punctuation, tokens[i+1].text == "!" else { return false }
+    guard tokens[i+2].element == .punctuation, tokens[i+2].text == "-" else { return false }
+    guard tokens[i+3].element == .punctuation, tokens[i+3].text == "-" else { return false }
+    var end = tokens.count - 1
+    if tokens[end].element == .newline || tokens[end].element == .eof { end -= 1 }
+    guard end >= 2 else { return false }
+    guard tokens[end-2].element == .punctuation, tokens[end-2].text == "-",
+          tokens[end-1].element == .punctuation, tokens[end-1].text == "-",
+          tokens[end].element == .punctuation, tokens[end].text == ">" else { return false }
+    let content = tokens[i...end].map { $0.text }.joined()
+    if let parent = context.current as? MarkdownNodeBase {
+      parent.append(HTMLBlockNode(name: "", content: content))
+      context.tokens = []
+      return true
+    }
+    return false
+  }
+}

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownIndentedCodeBlockResolvers.swift
@@ -67,13 +67,7 @@ public class MarkdownIndentedCodeBlockContinuationResolver: MarkdownBlockResolve
     if isBlank { return true }
 
     // Otherwise, end the code block and move current to parent
-    var leading = 0
-    if let t = tokens.first, t.element == .whitespaces {
-      leading = t.text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
-    }
-    if leading == 0, let code = context.current as? CodeBlockNode, code.source.hasSuffix("\n") {
-      code.source.removeLast()
-    }
+    // Preserve trailing newline per specification
     if let parent = context.current.parent { context.current = parent }
     return true
   }

--- a/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownReferenceDefinitionResolver.swift
+++ b/Sources/CodeParserCollection/Markdown/Nodes/Resolvers/MarkdownReferenceDefinitionResolver.swift
@@ -1,0 +1,62 @@
+import CodeParserCore
+import Foundation
+
+public class MarkdownReferenceDefinitionResolver: MarkdownBlockResolver {
+  public init() {}
+  public func resolve(from context: inout MarkdownBlockContext) -> Bool {
+    guard context.current.element != .codeBlock else { return false }
+    let tokens = context.tokens
+    var i = 0
+    var indent = 0
+    if i < tokens.count, tokens[i].element == .whitespaces {
+      indent = tokens[i].text.reduce(0) { $0 + ($1 == " " ? 1 : 0) }
+      i += 1
+    }
+    if let item = nearestListItem(from: context.current) {
+      if indent > item.contentIndent + 3 { return false }
+    } else if indent > 3 { return false }
+    guard i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == "[" else { return false }
+    i += 1
+    var label = ""
+    while i < tokens.count {
+      let t = tokens[i]
+      if t.element == .punctuation, t.text == "]" { break }
+      label.append(t.text)
+      i += 1
+    }
+    guard i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == "]" else { return false }
+    i += 1
+    guard i < tokens.count, tokens[i].element == .punctuation, tokens[i].text == ":" else { return false }
+    i += 1
+    while i < tokens.count, tokens[i].element == .whitespaces { i += 1 }
+    var dest = ""
+    while i < tokens.count {
+      let t = tokens[i]
+      if t.element == .newline || t.element == .eof { break }
+      dest.append(t.text)
+      i += 1
+    }
+    guard !dest.isEmpty else { return false }
+    let ref = ReferenceNode(identifier: label, url: dest, title: "")
+    if let item = nearestListItem(from: context.current), let list = item.parent as? MarkdownNodeBase, let parent = list.parent as? MarkdownNodeBase {
+      parent.append(ref)
+      context.current = list
+      context.tokens = []
+      return true
+    } else if let parent = context.current as? MarkdownNodeBase {
+      parent.append(ref)
+      context.tokens = []
+      return true
+    }
+    return false
+  }
+}
+
+private func nearestListItem(from node: CodeNode<MarkdownNodeElement>) -> ListItemNode? {
+  var cur = node as? MarkdownNodeBase
+  while let c = cur {
+    if let item = c as? ListItemNode { return item }
+    cur = c.parent as? MarkdownNodeBase
+  }
+  return nil
+}


### PR DESCRIPTION
## Summary
- refine paragraph handling within list context
- account for list indentation in fenced code blocks
- add HTML comment and link reference definition block resolvers

## Testing
- `swift test --filter MarkdownListsTests` *(fails: 20/26)*
- `swift test --filter MarkdownListItemsTests` *(fails: 20/39)*
- `swift test --filter MarkdownIndentedCodeBlocksTests`
- `swift test --filter MarkdownFencedCodeBlocksTests`
- `swift test --filter MarkdownATXHeadingsTests`
- `swift test --filter MarkdownParagraphsTests`
- `swift test --filter MarkdownSetextHeadingsTests`
- `swift test --filter MarkdownThematicBreaksTests`


------
https://chatgpt.com/codex/tasks/task_e_68c7dc2f7fc48322bf85564eb81780b4